### PR TITLE
TOC improvements

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -58,8 +58,11 @@ theme_variables:
   #   edit_me: true
   #   open_issue: true
   #   history: true
-  theme_color: 0d6efd
-  fonts:
+  # toc:
+  #   min_headers: 2
+  #   headers: 'h2'
+  # theme_color: 0d6efd
+  # fonts:
   # - url towards a font
 
 # --- Missing in gitlab: ---

--- a/_includes/toc.html
+++ b/_includes/toc.html
@@ -1,8 +1,8 @@
 <script>
   $(document).ready(function () {
-    $('#toc').toc({ minimumHeaders: 2, listType: 'ul', showSpeed: 0, headers: 'h2' , title: '' });
+    $('#toc').toc({ minimumHeaders: {{site.theme_variables.toc.min_headers | default: 2 }}, listType: 'ul', noBackToTopLinks: true, showSpeed: 0, headers: '{{site.theme_variables.toc.headers | default: 'main h2' }}' , title: '', classes:{toc:'p-3 rounded my-4'} });
   });
 </script>
 <div class="col-12 col-sm-7 col-xl-5">
-  <div id="toc" class="p-3 rounded my-4"></div>
+  <div id="toc"></div>
 </div>

--- a/assets/js/toc.js
+++ b/assets/js/toc.js
@@ -11,7 +11,8 @@
       showSpeed: 'slow', // set to 0 to deactivate effect
       classes: { list: '',
                  item: '',
-                 link: ''
+                 link: '', 
+                 toc: ''
                }
     },
     settings = $.extend(defaults, options);
@@ -43,6 +44,8 @@
     if (0 === settings.showSpeed) {
       settings.showEffect = 'none';
     }
+
+    $(this).addClass(settings.classes.toc)
 
     var render = {
       show: function() { output.hide().html(html).show(settings.showSpeed); },


### PR DESCRIPTION
- Styling is only added when the min headings requirement is met -> no jumping in the layout when there are less headers than `min_headers`
- New settings are added to the _config file with corresponding defaults:
  ```
  theme_variables: 
    toc:
      min_headers: 2
      headers: 'h2'
  ```
