### PR TITLE
Cookie banner fixes

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -10,7 +10,7 @@ description: "Flexible Jekyll theme using bootstrap 5 as CSS framework."
 dsw_deep_link_prefix:
 # prefix for DSW deep links to a certain question
 
-gtag: 
+gtag: dw
 # Google analytics tag
 
 plausible: 
@@ -60,6 +60,7 @@ plugins:
 theme_variables: 
   # git_host: GitHub
   # back_to_top: true
+  # privacy_statement_url: /privacy
   # github_buttons: 
   #   position: top
   #   edit_me: true
@@ -69,7 +70,7 @@ theme_variables:
   #   min_headers: 2
   #   headers: 'h2'
   # topnav:
-  #   brand_logo: assets/img/main_logo.svg
+    # brand_logo: assets/img/main_logo.svg
     # github: true
     # twitter: false
   # theme_color: 0d6efd

--- a/_config.yml
+++ b/_config.yml
@@ -10,7 +10,7 @@ description: "Flexible Jekyll theme using bootstrap 5 as CSS framework."
 dsw_deep_link_prefix:
 # prefix for DSW deep links to a certain question
 
-gtag: dw
+gtag:
 # Google analytics tag
 
 plausible: 

--- a/_includes/cookie-popup.html
+++ b/_includes/cookie-popup.html
@@ -1,11 +1,15 @@
 {%- if site.gtag %}
 <!-- START Bootstrap-Cookie-Alert -->
 <div class="alert text-center cookiealert rounded-0" role="alert">
-    We use cookies to ensure you get the best experience on our website. Read our
-    <a class="fw-bold" href="{{ '/privacy' | relative_url}}">privacy policy</a> to find out more.
-    <button type="button" id="acceptcookies" class="btn btn-primary ms-2">
-        Got it!
-    </button>
+    <p>
+        We use cookies to ensure you get the best experience on our website. Read our
+        <a class="fw-bold" href="{{ site.theme_variables.privacy_statement_url | default: '/privacy' | relative_url}}">privacy policy</a> to find out more.
+    </p>
+    <div class=""d-flex justify-content-cente>
+        <button type="button" id="acceptcookies" class="btn btn-primary ms-2">
+            Got it!
+        </button>
+    </div>
 </div>
 <script>
     /*

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -76,7 +76,7 @@ $(function () {
  * Back to top button
  */
 
- var toggleHeight = $(window).outerHeight() / 3;
+ var toggleHeight = $(window).outerHeight() / 2;
 
  $(window).scroll(function () {
    if ($(window).scrollTop() > toggleHeight) {


### PR DESCRIPTION
- [x] new theme variable to config the privacy statement url, will close #48 
  ```yaml
  theme_variables: 
    privacy_statement_url: /privacy
  ```
  
  optional with as default ` /privacy`
  
- [x] no overlap between Got it! button in cookie banner and back to top button in mobile mode