### PR TITLE
Updating National tools mechanics

### DIFF
--- a/_data/tool_and_resource_list.yml
+++ b/_data/tool_and_resource_list.yml
@@ -5,13 +5,14 @@
     biotools: bioconda
     tess: Bioconda
   related_pages:
-  - gp1
+    - gp1
 - description: Git based code hosting and collaboration tool, built for teams.
   link: https://bitbucket.org/
   name: Bitbucket
   related_pages:
-  - gp1
-- description: Versioning system, used for sharing code, as well as for sharing of
+    - gp1
+- description:
+    Versioning system, used for sharing code, as well as for sharing of
     small data
   link: https://github.com
   name: GitHub
@@ -19,8 +20,9 @@
     fairsharing-coll: bsg-d001160
     tess: GitHub
   related_pages:
-  - gp1
-- description: GitLab is an open source end-to-end software development platform with
+    - gp1
+- description:
+    GitLab is an open source end-to-end software development platform with
     built-in version control, issue tracking, code review, CI/CD, and more. Self-host
     GitLab on your own servers, in a container, or on a cloud provider.
   link: https://gitlab.com/gitlab-org/gitlab
@@ -28,8 +30,9 @@
   registry:
     tess: GitLab
   related_pages:
-  - gp1
-- description: Generalist research data repository built and developed by OpenAIRE
+    - gp1
+- description:
+    Generalist research data repository built and developed by OpenAIRE
     and CERN
   link: https://zenodo.org/
   name: Zenodo
@@ -37,4 +40,3 @@
     fairsharing: wy4egf
     tess: Zenodo
   related_pages:
-

--- a/_data/tool_and_resource_list.yml
+++ b/_data/tool_and_resource_list.yml
@@ -1,5 +1,5 @@
 - description: Bioconda is a bioinformatics channel for the Conda package manager
-  link: https://bioconda.github.io/
+  url: https://bioconda.github.io/
   name: Bioconda
   registry:
     biotools: bioconda
@@ -7,14 +7,14 @@
   related_pages:
     - gp1
 - description: Git based code hosting and collaboration tool, built for teams.
-  link: https://bitbucket.org/
+  url: https://bitbucket.org/
   name: Bitbucket
   related_pages:
     - gp1
 - description:
     Versioning system, used for sharing code, as well as for sharing of
     small data
-  link: https://github.com
+  url: https://github.com
   name: GitHub
   registry:
     fairsharing-coll: bsg-d001160
@@ -25,7 +25,7 @@
     GitLab is an open source end-to-end software development platform with
     built-in version control, issue tracking, code review, CI/CD, and more. Self-host
     GitLab on your own servers, in a container, or on a cloud provider.
-  link: https://gitlab.com/gitlab-org/gitlab
+  url: https://gitlab.com/gitlab-org/gitlab
   name: GitLab
   registry:
     tess: GitLab
@@ -34,7 +34,7 @@
 - description:
     Generalist research data repository built and developed by OpenAIRE
     and CERN
-  link: https://zenodo.org/
+  url: https://zenodo.org/
   name: Zenodo
   registry:
     fairsharing: wy4egf

--- a/_data/tool_and_resource_list.yml
+++ b/_data/tool_and_resource_list.yml
@@ -6,11 +6,12 @@
     tess: Bioconda
   related_pages:
     - gp1
+    - gp2
 - description: Git based code hosting and collaboration tool, built for teams.
   url: https://bitbucket.org/
   name: Bitbucket
   related_pages:
-    - gp1
+    - gp2
 - description:
     Versioning system, used for sharing code, as well as for sharing of
     small data
@@ -19,6 +20,7 @@
   registry:
     fairsharing-coll: bsg-d001160
     tess: GitHub
+  how_to_access: Zenodo
   related_pages:
     - gp1
 - description:
@@ -36,6 +38,7 @@
     and CERN
   url: https://zenodo.org/
   name: Zenodo
+  instance_of: test
   registry:
     fairsharing: wy4egf
     tess: Zenodo

--- a/_includes/resource-table-all.html
+++ b/_includes/resource-table-all.html
@@ -30,8 +30,8 @@
                 {%- assign instances_tool = 0 %}
                 {%- assign query = "related_pages." | append: page.type %}
                 {%- for country_page in country_pages %}
-                {%- assign instance_matches = country_page.resources | where: "instance_of", tool.name | where_exp:"resource","resource.related_pages != nil" | where: query, include.tag %}
-                {%- assign tool_matches = country_page.resources | where_exp:"resource","resource.related_pages != nil" | where: query, include.tag %}
+                {%- assign instance_matches = country_page.national_resources | where: "instance_of", tool.name | where_exp:"resource","resource.related_pages != nil" | where: query, include.tag %}
+                {%- assign tool_matches = country_page.national_resources | where_exp:"resource","resource.related_pages != nil" | where: query, include.tag %}
                 {%- unless tool_matches.size == 0 %}
                 {%- assign total_county_tools = total_county_tools | plus: tool_matches.size %}
                 {%- endunless %}
@@ -84,9 +84,9 @@
             {%- assign hide_ids = "resource_title" %}
             {%- for country_page in country_pages %}
             {%- if include.tag %}
-            {%- assign tool_matches = country_page.resources| where_exp:"resource","resource.related_pages != nil" | where: query, include.tag %}
+            {%- assign tool_matches = country_page.national_resources| where_exp:"resource","resource.related_pages != nil" | where: query, include.tag %}
             {%- else %}
-            {%- assign tool_matches = country_page.resources %}
+            {%- assign tool_matches = country_page.national_resources %}
             {%- endif %}
             {%- for tool in tool_matches %}
             {%- assign tool_id = tool.name | slugify %}

--- a/_includes/resource-table-all.html
+++ b/_includes/resource-table-all.html
@@ -39,8 +39,8 @@
                 {%- assign instances_tool = instances_tool | plus: instance_matches.size %}
                 {%- endunless %}
                 {%- endfor %}
-                {% if tool.link %}
-                <td><a href="{{tool.link}}">{{tool.name}}</a></td>
+                {% if tool.url %}
+                <td><a href="{{tool.url}}">{{tool.name}}</a></td>
                 {%- else %}
                 <td>{{tool.name}}</td>
                 {%- endif %}

--- a/_includes/resource-table-all.html
+++ b/_includes/resource-table-all.html
@@ -1,5 +1,5 @@
 {%- assign tools = site.data.tool_and_resource_list | where:"related_pages", include.tag %}
-{%- assign country_pages = site.pages | where_exp: "item", "item.search_exclude != true" | where_exp:"item","item.resources != nil" %}
+{%- assign country_pages = site.pages | where_exp: "item", "item.search_exclude != true" | where_exp:"item","item.national_resources != nil" %}
 {%- unless tools.size == 0 %}
 {%- if include.tag %}
 <h2>Relevant tools and resources</h2>
@@ -26,8 +26,8 @@
         <tbody>
             {%- for tool in tools | sort %}
             <tr>
-                {%- assign total_county_tools = 0 %}
                 {%- assign instances_tool = 0 %}
+                {%- assign total_county_tools = 0 %}
                 {%- assign query = "related_pages." | append: page.type %}
                 {%- for country_page in country_pages %}
                 {%- assign instance_matches = country_page.national_resources | where: "instance_of", tool.name | where_exp:"resource","resource.related_pages != nil" | where: query, include.tag %}
@@ -45,11 +45,21 @@
                 <td>{{tool.name}}</td>
                 {%- endif %}
                 <td>{{tool.description}}
-                    {%- unless instances_tool == 0 or total_county_tools == 0 or include.tag == nil %}
-                    <a href="#national-resources-button" class="d-block mt-1">
-                        <span class="badge text-white bg-primary"><i class="fa-solid fa-arrow-circle-down me-2"></i>Different instances available</span>
-                    </a>
-                    {%- endunless %}
+                    {%- if instances_tool or tool.instance_of or tool.how_to_access %}
+                    <div class="d-block mt-1">
+                        {%- if tool.instance_of %}
+                        <span class="d-inline-block" tabindex="0" data-bs-toggle="tooltip" title="This resource is an instance of {{tool.instance_of}}"><span class="badge text-primary border border-primary">{{tool.instance_of}}</span></span>
+                        {%- endif %}
+                        {%- if tool.how_to_access %}
+                        <span class="d-inline-block" tabindex="0" data-bs-toggle="tooltip" title="{{tool.how_to_access}}"><span class="badge text-primary border border-primary"> <i class="fa-solid fa-key"></i></span></span>
+                        {%- endif %}
+                        {%- unless instances_tool == 0 or total_county_tools == 0 or include.tag == nil %}    
+                        <a href="#national-resources-button">
+                            <span class="badge text-white bg-primary"><i class="fa-solid fa-arrow-circle-down me-2"></i>Different instances available</span>
+                        </a>
+                        {%- endunless %}
+                    </div>
+                    {%- endif %}
                 </td>
                 {%- capture related_pages %}
                 {%- for tag in tool.related_pages %}
@@ -124,7 +134,20 @@
                 {%- else %}
                 <td></td>
                 {%- endif %}
-                <td></td>
+                <td>
+                    {%- if tool.registry.biotools %}
+                    <a data-bs-toggle="tooltip" data-bs-original-title="Bio.tools" href="https://bio.tools/{{tool.registry.biotools}}"><span class="badge bg-dark text-white hover-primary"><i class="fa-solid fa-info me-2"></i>Tool info</span></a>
+                    {%- endif %}
+                    {%- if tool.registry.fairsharing %}
+                    <a data-bs-toggle="tooltip" data-bs-original-title="FAIRsharing" href="https://fairsharing.org/FAIRsharing.{{tool.registry.fairsharing}}"><span class="badge bg-dark text-white hover-primary"><i class="fa-solid fa-database me-2"></i>Standards/Databases</span></a>
+                    {%- endif %}
+                    {%- if tool.registry.fairsharing-coll %}
+                    <a data-bs-toggle="tooltip" data-bs-original-title="FAIRsharing collection" href="https://fairsharing.org/{{tool.registry.fairsharing-coll}}"><span class="badge bg-dark text-white hover-primary"><i class="fa-solid fa-database me-2"></i>Standards/Databases</span></a>
+                    {%- endif %}
+                    {%- if tool.registry.tess %}
+                    <a data-bs-toggle="tooltip" data-bs-original-title="TeSS" href="https://tess.elixir-europe.org/search?q={{tool.registry.tess}}"><span class="badge bg-dark text-white hover-primary"><i class="fa-solid fa-graduation-cap me-2"></i>Training</span></a>
+                    {%- endif %}
+                </td>
             </tr>
             {%- endfor %}
             {%- endfor %}

--- a/_includes/resource-table-all.html
+++ b/_includes/resource-table-all.html
@@ -45,7 +45,7 @@
                 <td>{{tool.name}}</td>
                 {%- endif %}
                 <td>{{tool.description}}
-                    {%- if instances_tool or tool.instance_of or tool.how_to_access %}
+                    {%- if instances_tool != 0 and total_county_tools != 0 and include.tag != nil or tool.instance_of or tool.how_to_access %}
                     <div class="d-block mt-1">
                         {%- if tool.instance_of %}
                         <span class="d-inline-block" tabindex="0" data-bs-toggle="tooltip" title="This resource is an instance of {{tool.instance_of}}"><span class="badge text-primary border border-primary">{{tool.instance_of}}</span></span>

--- a/_includes/resource-table-page.html
+++ b/_includes/resource-table-page.html
@@ -11,6 +11,11 @@
                 <th>Resource</th>
                 <th>Description</th>
                 <th>Related pages</th>
+                <th>Registry
+                    <a data-bs-toggle="tooltip" data-bs-original-title="Links to related information in ELIXIR registries: related policies and standards in FAIRsharing, scientific and technical descriptions of the resource in bio.tools, and related training in TeSS.">
+                        <i class="fa-solid fa-info-circle"></i>
+                    </a>
+                </th>
             </tr>
         </thead>
         <tbody>
@@ -49,6 +54,20 @@
                 {%- else %}
                 <td></td>
                 {%- endif %}
+                <td>
+                    {%- if tool.registry.biotools %}
+                    <a data-bs-toggle="tooltip" data-bs-original-title="Bio.tools" href="https://bio.tools/{{tool.registry.biotools}}"><span class="badge bg-dark text-white hover-primary"><i class="fa-solid fa-info me-2"></i>Tool info</span></a>
+                    {%- endif %}
+                    {%- if tool.registry.fairsharing %}
+                    <a data-bs-toggle="tooltip" data-bs-original-title="FAIRsharing" href="https://fairsharing.org/FAIRsharing.{{tool.registry.fairsharing}}"><span class="badge bg-dark text-white hover-primary"><i class="fa-solid fa-database me-2"></i>Standards/Databases</span></a>
+                    {%- endif %}
+                    {%- if tool.registry.fairsharing-coll %}
+                    <a data-bs-toggle="tooltip" data-bs-original-title="FAIRsharing collection" href="https://fairsharing.org/{{tool.registry.fairsharing-coll}}"><span class="badge bg-dark text-white hover-primary"><i class="fa-solid fa-database me-2"></i>Standards/Databases</span></a>
+                    {%- endif %}
+                    {%- if tool.registry.tess %}
+                    <a data-bs-toggle="tooltip" data-bs-original-title="TeSS" href="https://tess.elixir-europe.org/search?q={{tool.registry.tess}}"><span class="badge bg-dark text-white hover-primary"><i class="fa-solid fa-graduation-cap me-2"></i>Training</span></a>
+                    {%- endif %}
+                </td>
             </tr>
             {%- endfor %}
         </tbody>
@@ -59,7 +78,7 @@
 {%- if page.main_resources %}
 {%- assign tool_names = page.main_resources %}
 <h3>{{page.title}} is also involved in</h3>
-<p>These tools and resources can have a lead from {{page.title}} or is involved in the development.</p>
+<p>These tools and resources can have a lead from {{page.title}} or {{page.title}} is involved in the development.</p>
 <a class="visually-hidden-focusable" href='#skip-tool-table-1'>Skip tool table</a>
 <div class="table-responsive mt-4 mb-5">
     <table id="tooltable" class="table display">
@@ -68,6 +87,11 @@
                 <th>Resource</th>
                 <th>Description</th>
                 <th>Related pages</th>
+                <th>Registry
+                    <a data-bs-toggle="tooltip" data-bs-original-title="Links to related information in ELIXIR registries: related policies and standards in FAIRsharing, scientific and technical descriptions of the resource in bio.tools, and related training in TeSS.">
+                        <i class="fa-solid fa-info-circle"></i>
+                    </a>
+                </th>
             </tr>
         </thead>
         <tbody>
@@ -90,23 +114,29 @@
                     </div>
                     {%- endif %}
                 </td>
-                {%- if tool.related_pages %}
                 {%- capture related_pages %}
-                {%- for section in tool.related_pages %}
-                {%- unless section.size == 0 %}
-                {%- for tag in section[1] %}
+                {%- for tag in tool.related_pages %}
                 {%- unless tag == page.page_id %}
                 {%- assign related_page = site.pages | where:"page_id",tag | first %}
-                <a class="nohover" href="{{related_page.url | relative_url }}"><span class="badge default-badge">{{related_page.title}}</span></a>
-                {%- endunless %}
-                {%- endfor %}
+                <a href="{{related_page.url | relative_url }}"><span class="badge default-badge">{{related_page.title}}</span></a>
                 {%- endunless %}
                 {%- endfor %}
                 {%- endcapture %}
                 <td>{{related_pages}}</td>
-                {%- else %}
-                <td></td>
-                {%- endif %}
+                <td>
+                    {%- if tool.registry.biotools %}
+                    <a data-bs-toggle="tooltip" data-bs-original-title="Bio.tools" href="https://bio.tools/{{tool.registry.biotools}}"><span class="badge bg-dark text-white hover-primary"><i class="fa-solid fa-info me-2"></i>Tool info</span></a>
+                    {%- endif %}
+                    {%- if tool.registry.fairsharing %}
+                    <a data-bs-toggle="tooltip" data-bs-original-title="FAIRsharing" href="https://fairsharing.org/FAIRsharing.{{tool.registry.fairsharing}}"><span class="badge bg-dark text-white hover-primary"><i class="fa-solid fa-database me-2"></i>Standards/Databases</span></a>
+                    {%- endif %}
+                    {%- if tool.registry.fairsharing-coll %}
+                    <a data-bs-toggle="tooltip" data-bs-original-title="FAIRsharing collection" href="https://fairsharing.org/{{tool.registry.fairsharing-coll}}"><span class="badge bg-dark text-white hover-primary"><i class="fa-solid fa-database me-2"></i>Standards/Databases</span></a>
+                    {%- endif %}
+                    {%- if tool.registry.tess %}
+                    <a data-bs-toggle="tooltip" data-bs-original-title="TeSS" href="https://tess.elixir-europe.org/search?q={{tool.registry.tess}}"><span class="badge bg-dark text-white hover-primary"><i class="fa-solid fa-graduation-cap me-2"></i>Training</span></a>
+                    {%- endif %}
+                </td>
             </tr>
             {%- endfor %}
         </tbody>

--- a/_includes/resource-table-page.html
+++ b/_includes/resource-table-page.html
@@ -1,6 +1,7 @@
 {%- if page.national_resources %}
 {%- assign tools = page.national_resources %}
-<h2>National tools and resources</h2>
+<h2>Tools and resources</h2>
+<h3>Tailored to {{page.title}}</h3>
 <p>Developed and/or deployed by {{page.title}}.</p>
 <a class="visually-hidden-focusable" href='#skip-tool-table-1'>Skip tool table</a>
 <div class="table-responsive mt-4 mb-5">
@@ -57,8 +58,8 @@
 {%- endif %}
 {%- if page.main_resources %}
 {%- assign tool_names = page.main_resources %}
-<h2>Tools an resources {{page.title}} is involved with</h2>
-<p>These tools and resources can have a lead from {{page.title}} or this country is involved in the development contributions.</p>
+<h3>We are also involved in</h3>
+<p>These tools and resources can have a lead from {{page.title}} or we are involved in the development.</p>
 <a class="visually-hidden-focusable" href='#skip-tool-table-1'>Skip tool table</a>
 <div class="table-responsive mt-4 mb-5">
     <table id="tooltable" class="table display">

--- a/_includes/resource-table-page.html
+++ b/_includes/resource-table-page.html
@@ -1,7 +1,8 @@
-{%- if page.resources %}
-{%- assign tools = page.resources %}
-<h2>Relevant tools and resources</h2>
-<a class="visually-hidden-focusable" href='#skip-tool-table'>Skip tool table</a>
+{%- if page.national_resources %}
+{%- assign tools = page.national_resources %}
+<h2>National tools and resources</h2>
+<p>Developed and/or deployed by {{page.title}}.</p>
+<a class="visually-hidden-focusable" href='#skip-tool-table-1'>Skip tool table</a>
 <div class="table-responsive mt-4 mb-5">
     <table id="tooltable" class="table display">
         <thead>
@@ -52,6 +53,63 @@
         </tbody>
     </table>
 </div>
-<div id="skip-tool-table"></div>
-
+<div id="skip-tool-table-1"></div>
+{%- endif %}
+{%- if page.main_resources %}
+{%- assign tool_names = page.main_resources %}
+<h2>Tools an resources {{page.title}} is involved with</h2>
+<p>These tools and resources can have a lead from {{page.title}} or this country is involved in the development contributions.</p>
+<a class="visually-hidden-focusable" href='#skip-tool-table-1'>Skip tool table</a>
+<div class="table-responsive mt-4 mb-5">
+    <table id="tooltable" class="table display">
+        <thead>
+            <tr class="text-nowrap">
+                <th>Resource</th>
+                <th>Description</th>
+                <th>Related pages</th>
+            </tr>
+        </thead>
+        <tbody>
+            {%- for tool_name in tool_names | sort %}
+            {%- assign tool =  site.data.tool_and_resource_list | where:"name", tool_name | first %}
+            <tr>
+                {% if tool.url %}
+                <td><a href="{{tool.url}}">{{tool.name}}</a>
+                </td>
+                {%- else %}
+                <td>{{tool.name}}</td>
+                {%- endif %}
+                <td>{{tool.description | markdownify }}
+                    {%- if tool.instance_of or tool.how_to_access %}
+                    <div class="d-block mt-1">
+                        <span class="d-inline-block" tabindex="0" data-bs-toggle="tooltip" title="This resource is an instance of {{tool.instance_of}}"><span class="badge text-primary border border-primary">{{tool.instance_of}}</span></span>
+                        {%- if tool.how_to_access %}
+                        <span class="d-inline-block" tabindex="0" data-bs-toggle="tooltip" title="{{tool.how_to_access}}"><span class="badge text-primary border border-primary"> <i class="fa-solid fa-key"></i></span></span>
+                        {%- endif %}
+                    </div>
+                    {%- endif %}
+                </td>
+                {%- if tool.related_pages %}
+                {%- capture related_pages %}
+                {%- for section in tool.related_pages %}
+                {%- unless section.size == 0 %}
+                {%- for tag in section[1] %}
+                {%- unless tag == page.page_id %}
+                {%- assign related_page = site.pages | where:"page_id",tag | first %}
+                <a class="nohover" href="{{related_page.url | relative_url }}"><span class="badge default-badge">{{related_page.title}}</span></a>
+                {%- endunless %}
+                {%- endfor %}
+                {%- endunless %}
+                {%- endfor %}
+                {%- endcapture %}
+                <td>{{related_pages}}</td>
+                {%- else %}
+                <td></td>
+                {%- endif %}
+            </tr>
+            {%- endfor %}
+        </tbody>
+    </table>
+</div>
+<div id="skip-tool-table-1"></div>
 {%- endif %}

--- a/_includes/resource-table-page.html
+++ b/_includes/resource-table-page.html
@@ -58,8 +58,8 @@
 {%- endif %}
 {%- if page.main_resources %}
 {%- assign tool_names = page.main_resources %}
-<h3>We are also involved in</h3>
-<p>These tools and resources can have a lead from {{page.title}} or we are involved in the development.</p>
+<h3>{{page.title}} is also involved in</h3>
+<p>These tools and resources can have a lead from {{page.title}} or is involved in the development.</p>
 <a class="visually-hidden-focusable" href='#skip-tool-table-1'>Skip tool table</a>
 <div class="table-responsive mt-4 mb-5">
     <table id="tooltable" class="table display">

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -39,10 +39,6 @@ main {
         margin-top: $spacer * 1.5;
     }
 
-    h2+h3 {
-        margin-top: $spacer * 0.5;
-    }
-
     h3+h4 {
         margin-top: $spacer * 0.25;
     }

--- a/pages/example_pages/general_page_3.md
+++ b/pages/example_pages/general_page_3.md
@@ -16,6 +16,9 @@ national_resources:
     instance_of: GitHub
     related_pages:
       example_pages: [gp3, gp1, gp2]
+    registry:
+      biotools: bioconda
+      tess: Bioconda
   - name: Resource name 2
     description: A general description about the resource
     how_to_access: 

--- a/pages/example_pages/general_page_3.md
+++ b/pages/example_pages/general_page_3.md
@@ -4,11 +4,16 @@ type: example_pages
 description: This page has page level resources
 country_code: BE
 page_id: gp3
-resources:
+
+main_resources:
+  - Bioconda
+  - GitHub
+
+national_resources:
   - name: Resource name
     description: A general description about the resource
     how_to_access: explantation on how you can access this resource
-    instance_of: based on
+    instance_of: GitHub
     related_pages:
       example_pages: [gp3, gp1, gp2]
   - name: Resource name 2


### PR DESCRIPTION
BREAKING CHANGES:
- `resources` is now called `national_resources` in national pages
- In the main tools table the `link` column is now called `url`

The syntax for the metadata in national pages looks now like this, it has the `national_resources` object and the `main_resources` object if needed. `main_resources` are just a list of tools from the main resources table and is used to refer to other tools, `national_resources` is for the national tools like we used them before.

```yml
national_resources:
  - name: GFBio Data Management Plan Tool
    related_pages:
      your_tasks: [DMP]
    url: https://www.gfbio.org/plan

main_resources:
  - e!DAL-PGP
  - FAIRDOM-SEEK
  - PANGAEA
```
national resources now also support registries, which can be used like this:
```yml
national_resources:
  - name: Resource name
    description: A general description about the resource
    how_to_access: explantation on how you can access this resource
    instance_of: GitHub
    related_pages:
      example_pages: [gp3, gp1, gp2]
    registry:
      biotools: bioconda
      tess: Bioconda
```

and the main tools table supports how_to_access and instance_of

This will close #74 