### PR TITLE
Better keyword generation in metadata

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -7,14 +7,16 @@
     {%- if page.related_pages %}
     {%- for section in page.related_pages %}
     {%- unless section[1] == nil %}
-    {%- assign keywordstr = section[1] | join: ', ' %}
+    {%- for keywordstr in section[1] %}
+    {%- assign keywordpage = site.pages | where: keywordstr, page_id | first  %}
     {%- if allkeywords %}
-    {%- assign allkeywords = allkeywords | append: ", " | append: keywordstr %}
+    {%- assign allkeywords = allkeywords | append: ", " | append: keywordstr | append: ", " | append: keywordpage.title %}
     {%- else %}
     {%- assign allkeywords = allkeywords | append: keywordstr %}
     {%- endif %}
+    {%- endfor %}
     {%- endunless %}
-    {%- endfor %}{{allkeywords}}
+    {%- endfor %}{%- assign allkeywords = allkeywords | split: ", " | uniq | sort %}{{allkeywords | join: ", "}}
     {%- endif %}
     {%- endcapture %}
     <meta name="keywords" content="{{keywords}}">

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -8,11 +8,11 @@
     {%- for section in page.related_pages %}
     {%- unless section[1] == nil %}
     {%- for keywordstr in section[1] %}
-    {%- assign keywordpage = site.pages | where: keywordstr, page_id | first  %}
+    {%- assign keywordpage = site.pages | where: "page_id", keywordstr | first  %}
     {%- if allkeywords %}
     {%- assign allkeywords = allkeywords | append: ", " | append: keywordstr | append: ", " | append: keywordpage.title %}
     {%- else %}
-    {%- assign allkeywords = allkeywords | append: keywordstr %}
+    {%- assign allkeywords = allkeywords | append: keywordstr | append: ", " | append: keywordpage.title %}
     {%- endif %}
     {%- endfor %}
     {%- endunless %}

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -16,7 +16,7 @@
     {%- endif %}
     {%- endfor %}
     {%- endunless %}
-    {%- endfor %}{%- assign allkeywords = allkeywords | split: ", " | uniq | sort %}{{allkeywords | join: ", "}}
+    {%- endfor %}{{allkeywords}}
     {%- endif %}
     {%- endcapture %}
     <meta name="keywords" content="{{keywords}}">

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -6,9 +6,15 @@
     {%- capture keywords %}
     {%- if page.related_pages %}
     {%- for section in page.related_pages %}
-    {%- unless section[1] == nil %}{{ section[1] | join: ', ' }}
+    {%- unless section[1] == nil %}
+    {%- assign keywordstr = section[1] | join: ', ' %}
+    {%- if allkeywords %}
+    {%- assign allkeywords = allkeywords | append: ", " | append: keywordstr %}
+    {%- else %}
+    {%- assign allkeywords = allkeywords | append: keywordstr %}
+    {%- endif %}
     {%- endunless %}
-    {%- endfor %}
+    {%- endfor %}{{allkeywords}}
     {%- endif %}
     {%- endcapture %}
     <meta name="keywords" content="{{keywords}}">


### PR DESCRIPTION
before: 
```
<meta name="keywords" content="sensitiveTSD, Covid-19, transmed">
```
after:
```
<meta name="keywords" content="COVID-19 Data Portal, Covid-19, Sensitive data, TSD, TransMed, sensitive, transmed">
```
also including titles and better comma placing