### PR TITLE
Adding except param to navigation tiles

### DIFF
--- a/_includes/section-navigation-tiles.html
+++ b/_includes/section-navigation-tiles.html
@@ -163,10 +163,10 @@
                         {%- endfor %}
                 </div>
             </div>
-            {% endunless %}
             {%- endif %}
         </div>
     </div>
+    {% endunless %}
     {%- endif %}
     {%- endfor %}
 </div>

--- a/_includes/section-navigation-tiles.html
+++ b/_includes/section-navigation-tiles.html
@@ -52,7 +52,7 @@
     {%- assign related_pages_classes = "" %}
     {%- assign except = include.except | split: ", " %}
     {%- if current_page.title and current_page.search_exclude != true and current_page.type == include.type %}
-    {%- unless except contains page.name %}
+    {%- unless except contains current_page.name %}
     {%- if current_page.affiliations %}
     {%- capture affiliations_classes -%}
     {%- assign affiliations_output = "" %}

--- a/_includes/section-navigation-tiles.html
+++ b/_includes/section-navigation-tiles.html
@@ -50,7 +50,9 @@
     {%- for current_page in site.pages | sorted %}
     {%- assign affiliations_classes = "" %}
     {%- assign related_pages_classes = "" %}
+    {%- assign except = include.except | split: ", " %}
     {%- if current_page.title and current_page.search_exclude != true and current_page.type == include.type %}
+    {%- unless except contains page.name %}
     {%- if current_page.affiliations %}
     {%- capture affiliations_classes -%}
     {%- assign affiliations_output = "" %}
@@ -161,6 +163,7 @@
                         {%- endfor %}
                 </div>
             </div>
+            {% endunless %}
             {%- endif %}
         </div>
     </div>

--- a/pages/example_pages/overview_tiles.md
+++ b/pages/example_pages/overview_tiles.md
@@ -9,12 +9,17 @@ Nam non sollicitudin sapien. Vestibulum ante ipsum primis in faucibus orci luctu
 ## Section tiles with information
 ```
 {% raw %}
-{% include section-navigation-tiles.html type="example_pages" affiliations=true search=true %}
+{% include section-navigation-tiles.html type="example_pages" affiliations=true search=true except="index.md" %}
 {% endraw %}
 ```
 
+### Parameters
 
-{% include section-navigation-tiles.html type="example_pages" affiliations=true search=true %}
+* `affiliations`: Turn on filtering by affiliation
+* `search`: enable search in the tiles
+* `except`: `, ` separated list of page names which should be excluded, including the file extension
+
+{% include section-navigation-tiles.html type="example_pages" affiliations=true search=true except="index.md" %}
 
 
 ## Section tiles simple


### PR DESCRIPTION
Example of how to use the snippet with param:
```
{% include section-navigation-tiles.html type="example_pages" affiliations=true search=true except="index.md" %}
```

* `except`: `, ` separated list of page names which should be excluded, including the file extension
