### PR TITLE
Add caption_url param to events and news include

### DIFF
--- a/_data/sidebars/main.yml
+++ b/_data/sidebars/main.yml
@@ -36,7 +36,7 @@ subitems:
         url: /contributors
       - title: Events
         url: /events
-      - title: News page
+      - title: News
         url: /news
       - title: Logo page
         url: /logo_page

--- a/_includes/events.html
+++ b/_includes/events.html
@@ -33,7 +33,7 @@
     {%- endfor %}
   </ul>
   {%- if include.caption == true%}
-  {%- assign caption_url = include.caption_url | default: "/about/news" %}
+  {%- assign caption_url = include.caption_url | default: "/events" %}
   <small>An overview of all our events can be fount on the <a href="{{ caption_url | relative_url}}">events page</a>.</small>
   {%- endif %}
 </div>

--- a/_includes/events.html
+++ b/_includes/events.html
@@ -33,7 +33,8 @@
     {%- endfor %}
   </ul>
   {%- if include.caption == true%}
-  <small>An overview of all our events can be fount on the <a href="{{'/events' | relative_url}}">events page</a>.</small>
+  {%- assign caption_url = include.caption_url | default: "/about/news" %}
+  <small>An overview of all our events can be fount on the <a href="{{ caption_url | relative_url}}">events page</a>.</small>
   {%- endif %}
 </div>
 <script>

--- a/_includes/news.html
+++ b/_includes/news.html
@@ -31,7 +31,7 @@
     {%- endfor %}
   </ul>
   {%- if include.caption == true %}
-  {%- assign caption_url = include.caption_url | default: "/about/events" %}
+  {%- assign caption_url = include.caption_url | default: "/news" %}
   <small>For more news please visit our <a href="{{ caption_url | relative_url }}">news page</a>.</small>
   {%- endif %}
 </div>

--- a/_includes/news.html
+++ b/_includes/news.html
@@ -31,6 +31,7 @@
     {%- endfor %}
   </ul>
   {%- if include.caption == true %}
-  <small>For more news please visit our <a href="{{ '/news' | relative_url }}">news page</a>.</small>
+  {%- assign caption_url = include.caption_url | default: "/about/events" %}
+  <small>For more news please visit our <a href="{{ caption_url | relative_url }}">news page</a>.</small>
   {%- endif %}
 </div>

--- a/elixir-toolkit-theme.gemspec
+++ b/elixir-toolkit-theme.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |spec|
   spec.name          = "elixir-toolkit-theme"
-  spec.version       = "1.19.1"
+  spec.version       = "1.19.2"
   spec.authors       = ["bedroesb"]
   spec.email         = ["bedro@psb.vib-ugent.be\n"]
 

--- a/pages/example_pages/events.md
+++ b/pages/example_pages/events.md
@@ -2,9 +2,38 @@
 title: Events
 ---
 
-{% include events.html event_type="upcoming_event" title=true truncate=true %}
+## Simple example with past events
+
+```
+{% raw %}
+{% include events.html event_type="past_event" %}
+{% endraw %}
+```
+
+Becomes:
+
+{% include events.html event_type="past_event" %}
+
+## More complex example with upcoming events
+
+```
+{% raw %}
+{% include events.html caption=true title=true event_type="upcoming_event" caption_url="/about/events" truncate=true %}
+{% endraw %}
+```
+
+Becomes:
+
+{% include events.html caption=true title=true event_type="upcoming_event" caption_url="/about/events" truncate=true %}
+
+### Parameters
+
+* `event_type`: MANDATORY! *upcoming_event* or *past_event* as value
+* `title`: Visualize the *event_type* as title when events are present from this type. Use *true* as value to enable this.
+* `caption`: Show the "An overview of all our events can be fount on the events page." by using *true*.
+* `caption_url`: Add a custom url if the main events page is not served at */events*
+* `truncate`: If longer event descriptions are used and this parameter is set to *true*, descriptions which are longer than 40 words will get collapsed behind a button. 
 
 
-{% include events.html event_type="past_event" title=true truncate=true %}
 
 

--- a/pages/example_pages/news.md
+++ b/pages/example_pages/news.md
@@ -3,4 +3,37 @@ title: News
 toc: false
 ---
 
-{% include news.html truncate=true caption=true %}
+
+## Simple example
+
+```
+{% raw %}
+{% include news.html %}
+{% endraw %}
+```
+
+
+Becomes:
+{% include news.html %}
+
+## More complex example
+
+```
+{% raw %}
+{% include news.html title=true truncate=true caption=true caption_url="/about/news" %}
+{% endraw %}
+```
+
+Becomes:
+
+{% include news.html title=true truncate=true caption=true caption_url="/about/news" %}
+
+
+### Parameters
+
+* `title`: Visualize *What's new?* as title. Use *true* as value to enable this.
+* `caption`: Show the "For more news please visit our news page." by using *true*.
+* `caption_url`: Add a custom url if the main news page is not served at */news*
+* `truncate`: If longer event descriptions are used and this parameter is set to *true*, descriptions which are longer than 40 words will get collapsed behind a button. 
+
+

--- a/pages/example_pages/overview_tiles.md
+++ b/pages/example_pages/overview_tiles.md
@@ -13,13 +13,15 @@ Nam non sollicitudin sapien. Vestibulum ante ipsum primis in faucibus orci luctu
 {% endraw %}
 ```
 
+Becomes:
+
+{% include section-navigation-tiles.html type="example_pages" affiliations=true search=true except="index.md" %}
+
 ### Parameters
 
 * `affiliations`: Turn on filtering by affiliation
 * `search`: enable search in the tiles
 * `except`: `, ` separated list of page names which should be excluded, including the file extension
-
-{% include section-navigation-tiles.html type="example_pages" affiliations=true search=true except="index.md" %}
 
 
 ## Section tiles simple


### PR DESCRIPTION
Custom caption url will can be chosen for `For more news please visit our ` and `An overview of all our events can be fount on the` url's 

Defaults are /news and /events