### PR TITLE
Fixing the appearance of empty contributor cards

### DIFF
--- a/_includes/contributor-tiles-all.html
+++ b/_includes/contributor-tiles-all.html
@@ -3,7 +3,7 @@
 {%- assign allcontributors = include.custom | split: ", " | sort %}
 {%- else %}
 {%- for page in site.pages %}
-{%- if page.contributors and page.search_exclude != true %}
+{%- if page.contributors and page.search_exclude != true and page.contributors.size != 0 %}
 {%- assign pagecontr = page.contributors | join: ", " %}
 {%- if allcontrstr %}
 {%- assign allcontrstr = allcontrstr | append: ", " | append: pagecontr %}


### PR DESCRIPTION
Allow the use of empty lists in the `contributors:` metatdata field of the page.