### PR TITLE
Adding GitHub as Training registry

### DIFF
--- a/_includes/more-information-tiles.html
+++ b/_includes/more-information-tiles.html
@@ -60,11 +60,13 @@
                                 {%- elsif registry == "zenodo" %}
                                 <img alt="Zenodo logo" class="img-fluid" src="{{ 'assets/img/zenodo_logo.svg' | relative_url }}">
                                 {%- elsif registry == "youtube" %}
-                                <img alt="Youtube logo" class="img-fluid" src="{{ 'assets/img/youtube_logo.svg' | relative_url }}">
+                                <img alt="YouTube logo" class="img-fluid" src="{{ 'assets/img/youtube_logo.svg' | relative_url }}">
                                 {%- elsif registry == "carpentries" %}
                                 <img alt="Carpentries" class="img-fluid" src="{{ 'assets/img/carpentries_logo.svg' | relative_url }}">
+                                {%- elsif registry == "github" %}
+                                <i class="fa-brands fa-github text-dark fa-2xl my-3"></i>
                                 {%- else %}
-                                <i class="fa-solid fa-external-link-alt text-primary fs-5"></i>
+                                <i class="fa-solid fa-external-link-alt text-primary fa-lg my-3"></i>
                                 {%- endif %}
                             </div>
                             <div class="col-10 d-flex align-items-center">

--- a/pages/documentation/page_mechanics.md
+++ b/pages/documentation/page_mechanics.md
@@ -72,6 +72,8 @@ title: Title of the page
       url: https://tess.elixir-europe.org/search?q=data%20analysis
   ```
 
+  The supported registries that can be used in the `registry` attribute are: *YouTube*, *Zenodo*, *Carpentries*, *GitHub*, and *TeSS*.
+
 * `faircookbook`: List here all the links towards FAIR Cookbook recipes.
 
   ```yml
@@ -80,7 +82,17 @@ title: Title of the page
     url: https://fairplus.github.io/the-fair-cookbook/content/recipes/reusability/ATI_licensing_data.html
   ```
 
+* `dsw`: Here all relevant Data Stewardship Wizard questions in the Researcher knowledge model are listed. 
 
+  ```yml
+  dsw:
+  - name: Will you monitor data integrity once it has been collected?
+    uuid: 02b3fed1-0b50-4a80-b8b6-a225a1107022
+  ```
+  Where the `uuid` resembles the uuid towards a question in a knowledge model specified with the `dsw_deep_link_prefix` attribute in the `[/_config.yml](/_config.yml)` file. Example:
+  ```yml
+  dsw_deep_link_prefix: https://researchers.ds-wizard.org/knowledge-models/dsw:root:latest/preview?questionUuid=
+  ```
 
 ### Tools and resources
 

--- a/pages/documentation/page_mechanics.md
+++ b/pages/documentation/page_mechanics.md
@@ -66,10 +66,6 @@ title: Title of the page
     - name: Training in TeSS
       registry: TeSS
       url: https://tess.elixir-europe.org/search?q=data%20analysis
-
-    - name: Training in TeSS
-      registry: TeSS
-      url: https://tess.elixir-europe.org/search?q=data%20analysis
   ```
 
   The supported registries that can be used in the `registry` attribute are: *YouTube*, *Zenodo*, *Carpentries*, *GitHub*, and *TeSS*.

--- a/pages/example_pages/general_page_2.md
+++ b/pages/example_pages/general_page_2.md
@@ -23,13 +23,19 @@ training:
     url: https://tess.elixir-europe.org/
   - name: Training in Zenodo
     registry: Zenodo
-    url: https://tess.elixir-europe.org/
+    url: https://zenodo.org/record/7277814
   - name: Training on Youtube
     registry: Youtube
-    url: https://tess.elixir-europe.org/
+    url: https://www.youtube.com/
   - name: Training in The Carpentries
     registry: Carpentries
-    url: https://tess.elixir-europe.org/
+    url: https://datacarpentry.org/
+  - name: Training in GitHub
+    registry: GitHub
+    url: https://github.com/ELIXIR-Belgium/elixir-toolkit-theme/
+  - name: Training
+    registry: 
+    url: https://github.com/ELIXIR-Belgium/
 
 
 ---

--- a/pages/example_pages/general_page_2.md
+++ b/pages/example_pages/general_page_2.md
@@ -24,8 +24,8 @@ training:
   - name: Training in Zenodo
     registry: Zenodo
     url: https://zenodo.org/record/7277814
-  - name: Training on Youtube
-    registry: Youtube
+  - name: Training on YouTube
+    registry: YouTube
     url: https://www.youtube.com/
   - name: Training in The Carpentries
     registry: Carpentries


### PR DESCRIPTION
  The supported registries that can be used in the `registry` attribute are now: *YouTube*, *Zenodo*, *Carpentries*, *GitHub*, and *TeSS*.
  
  
![Screenshot from 2022-11-18 17-12-43](https://user-images.githubusercontent.com/44875756/202753066-09862338-d436-484a-a110-e34d9db93712.png)
