### PR TITLE
Bug fix: country url in section navigation tiles not working

### DIFF
--- a/_includes/section-navigation-tiles.html
+++ b/_includes/section-navigation-tiles.html
@@ -145,7 +145,7 @@
                     {%- if affiliation.size == 2 %}
                     {%- assign country_link = site.pages | where:"country_code",country | first %}
                     {%- if country_link %}
-                    <a role="button" href="{{'country_link.url' | relative_url}}" data-bs-toggle="tooltip" title="{{allcountries[country]}}" class="btn btn-sm bg-white hover-primary">
+                    <a role="button" href="{{country_link.url | relative_url}}" data-bs-toggle="tooltip" title="{{allcountries[country]}}" class="btn btn-sm bg-white hover-primary">
                         {%- else %}
                         <a role="button" data-bs-toggle="tooltip" title="{{allcountries[country]}}" class="btn btn-sm bg-white hover-primary disabled" aria-disabled="true">
                             {%- endif %}


### PR DESCRIPTION
![Screenshot from 2022-11-18 17-30-15](https://user-images.githubusercontent.com/44875756/202754154-f86b6e08-8cd6-4fa6-8e01-a845f936d4af.png)

Variable is used instead of its string