### PR TITLE
Start with separate national tools

### DIFF
--- a/_includes/resource-table-all.html
+++ b/_includes/resource-table-all.html
@@ -86,6 +86,32 @@
                 </td>
             </tr>
             {%- endfor %}
+            
+        </tbody>
+    </table>
+</div>
+
+<h3>Tailored to users in different countries</h3>
+<p>Developed and/or deployed by institutions and organisations on national level.</p>
+<div class="table-responsive mt-4 mb-5">
+    <table class="tooltable table display" id="national-resources-button">
+        <thead>
+            <tr class="text-nowrap">
+                <th>Tool or resource {%- if include.tag -%}
+                    <a data-bs-toggle="tooltip" data-bs-original-title="This is a curated list which means that not all tools or resources that exist for this topic are listed here. This is mainly because we do not intend to be a registry. In most cases you will only find back the tools or resources that are mentioned in this page.">
+                        <i class="fa-solid fa-info-circle"></i>
+                    </a>{%- endif %}
+                </th>
+                <th>Description</th>
+                <th>Related pages</th>
+                <th>Registry {%- if include.tag -%}
+                    <a data-bs-toggle="tooltip" data-bs-original-title="Links to related information in ELIXIR registries: related policies and standards in FAIRsharing, scientific and technical descriptions of the resource in bio.tools, and related training in TeSS.">
+                        <i class="fa-solid fa-info-circle"></i>
+                    </a>{%- endif %}
+                </th>
+            </tr>
+        </thead>
+        <tbody>
             {%- unless total_county_tools == 0 or include.tag == nil %}
             <tr class="collapse multi-collapse bg-light" id="resource_title">
                 <td colspan="4"><b>National resources</b></td>
@@ -101,7 +127,7 @@
             {%- for tool in tool_matches %}
             {%- assign tool_id = tool.name | slugify %}
             {%- assign hide_ids = hide_ids | append: " " | append: tool_id %}
-            <tr {% unless include.tag==nil %} class="collapse multi-collapse" id="{{tool_id}}" {% endunless %}>
+            <tr>
                 {% if tool.url %}
                 <td><a href="{{tool.url}}">{{tool.name}}</a><a href="{{country_page.url | relative_url }}" data-bs-toggle="tooltip" title="{{country_page.title}}"><span class="flag-icon ms-2 flag-icon-{{country_page.country_code | downcase }}"></span></a></td>
                 {%- else %}
@@ -154,10 +180,6 @@
         </tbody>
     </table>
 </div>
-{%- unless total_county_tools == 0 or include.tag == nil %}
-<a class="btn btn-primary" id="national-resources-button" data-bs-toggle="collapse" data-bs-target=".multi-collapse" role="button" aria-expanded="false" aria-controls="{{hide_ids}}">
-    View national resources <span class="badge bg-white text-primary ms-2">{{total_county_tools}}</span>
-</a>
-{%- endunless %}
+
 <div id="skip-tool-table"></div>
 {%- endunless %}


### PR DESCRIPTION
I think the whole 'instance of' and national tools experience needs to be better.

First step I thought was to have a separate tools table for national tools similar as a on the national resources pages 


![Screenshot from 2022-11-23 17-01-43](https://user-images.githubusercontent.com/44875756/203592796-deb51111-f73e-428a-8680-771c2a0d5ae4.png)
