### PR TITLE
Add section as tooltip in related pages badges of tools

### DIFF
--- a/_includes/resource-table-all.html
+++ b/_includes/resource-table-all.html
@@ -65,7 +65,7 @@
                 {%- for tag in tool.related_pages %}
                 {%- unless tag == page.page_id %}
                 {%- assign related_page = site.pages | where:"page_id",tag | first %}
-                <a href="{{related_page.url | relative_url }}"><span class="badge default-badge">{{related_page.title}}</span></a>
+                <a href="{{related_page.url | relative_url }}" data-bs-toggle="tooltip" title="{{related_page.type | replace: '_', ' ' | capitalize}}"><span class="badge default-badge">{{related_page.title}}</span></a>
                 {%- endunless %}
                 {%- endfor %}
                 {%- endcapture %}
@@ -124,7 +124,7 @@
                 {%- for tag in section[1] %}
                 {%- unless tag == page.page_id %}
                 {%- assign related_page = site.pages | where:"page_id",tag | first %}
-                <a class="nohover" href="{{related_page.url | relative_url }}"><span class="badge default-badge">{{related_page.title}}</span></a>
+                <a class="nohover" href="{{related_page.url | relative_url }}" data-bs-toggle="tooltip" title="{{related_page.type | replace: '_', ' ' | capitalize}}"><span class="badge default-badge">{{related_page.title}}</span></a>
                 {%- endunless %}
                 {%- endfor %}
                 {%- endunless %}

--- a/_includes/resource-table-page.html
+++ b/_includes/resource-table-page.html
@@ -44,7 +44,7 @@
                 {%- for tag in section[1] %}
                 {%- unless tag == page.page_id %}
                 {%- assign related_page = site.pages | where:"page_id",tag | first %}
-                <a class="nohover" href="{{related_page.url | relative_url }}"><span class="badge default-badge">{{related_page.title}}</span></a>
+                <a class="nohover" href="{{related_page.url | relative_url }}"  data-bs-toggle="tooltip" title="{{related_page.type | replace: '_', ' ' | capitalize}}"><span class="badge default-badge">{{related_page.title}}</span></a>
                 {%- endunless %}
                 {%- endfor %}
                 {%- endunless %}
@@ -118,7 +118,7 @@
                 {%- for tag in tool.related_pages %}
                 {%- unless tag == page.page_id %}
                 {%- assign related_page = site.pages | where:"page_id",tag | first %}
-                <a href="{{related_page.url | relative_url }}"><span class="badge default-badge">{{related_page.title}}</span></a>
+                <a href="{{related_page.url | relative_url }}"  data-bs-toggle="tooltip" title="{{related_page.type | replace: '_', ' ' | capitalize}}"><span class="badge default-badge">{{related_page.title}}</span></a>
                 {%- endunless %}
                 {%- endfor %}
                 {%- endcapture %}


### PR DESCRIPTION
![Screenshot from 2023-02-09 17-35-10](https://user-images.githubusercontent.com/44875756/217878085-ef930823-98af-4d8a-b5bf-7c0d6daed74b.png)

This way, similar named pages that are located in different sections, can be differentiated. Example: https://www.infectious-diseases-toolkit.org/

@rabuono  