### PR TITLE
Use custom edit me path for history button + custom_editme attribute name change

### DIFF
--- a/_includes/github-buttons.html
+++ b/_includes/github-buttons.html
@@ -1,8 +1,8 @@
 {%- if site.theme_variables.github_buttons.edit_me or site.theme_variables.github_buttons.open_issue or site.theme_variables.github_buttons.history or site.theme_variables.github_buttons.edit_me == nil or site.theme_variables.github_buttons.open_issue == nil or site.theme_variables.github_buttons.history == nil %}
 <div id="edit-me" class="btn-group">
     {%- if site.theme_variables.github_buttons.edit_me or site.theme_variables.github_buttons.edit_me == nil %}
-    {%- if page.custom-editme %}
-    <a role="button" data-bs-toggle="tooltip" title="Propose changes to the content of this page on {{site.theme_variables.git_host | default: 'GitHub' }}" href="{{site.github.repository_url}}/blob/{{site.github.source.branch}}/{{page.custom-editme}}" class="btn btn-sm hover-primary text-primary"><i class="fa-solid fa-pencil-alt"></i></a>
+    {%- if page.custom_editme %}
+    <a role="button" data-bs-toggle="tooltip" title="Propose changes to the content of this page on {{site.theme_variables.git_host | default: 'GitHub' }}" href="{{site.github.repository_url}}/blob/{{site.github.source.branch}}/{{page.custom_editme}}" class="btn btn-sm hover-primary text-primary"><i class="fa-solid fa-pencil-alt"></i></a>
     {%- else %}
     <a role="button" data-bs-toggle="tooltip" title="Propose changes to this page on {{site.theme_variables.git_host | default: 'GitHub' }}"  href="{{site.github.repository_url}}/blob/{{site.github.source.branch}}/{{page.path}}" class="btn btn-sm hover-primary text-primary"><i class="fa-solid fa-pencil-alt"></i></a>
     {%- endif %}
@@ -11,8 +11,8 @@
     <a role="button" data-bs-toggle="tooltip" title="Report an issue" href="{{site.github.repository_url}}/issues/new?title={{'Issue on page: ' | url_encode }}{{page.title | url_encode }}&amp;body={{'I would like to report an issue on the ' | url_encode }}{{page.title | url_encode }}{{' page at `'| url_encode }}{{page.url | url_encode }}{{'`. Description of the issue:' | url_encode }}" class="btn btn-sm hover-primary text-primary"><i class="fa-solid fa-exclamation"></i></a>
     {%- endif %}
     {%- if site.theme_variables.github_buttons.history or site.theme_variables.github_buttons.history == nil %}
-    {%- if page.custom-editme %}
-    <a role="button" data-bs-toggle="tooltip" title="Check out the history of this page" href="{{site.github.repository_url}}/commits/{{site.github.source.branch}}/{{page.custom-editme}}" class="btn btn-sm hover-primary text-primary"><i class="fa-solid fa-history"></i></a>
+    {%- if page.custom_editme %}
+    <a role="button" data-bs-toggle="tooltip" title="Check out the history of this page" href="{{site.github.repository_url}}/commits/{{site.github.source.branch}}/{{page.custom_editme}}" class="btn btn-sm hover-primary text-primary"><i class="fa-solid fa-history"></i></a>
     {%- else %}
     <a role="button" data-bs-toggle="tooltip" title="Check out the history of this page" href="{{site.github.repository_url}}/commits/{{site.github.source.branch}}/{{page.path}}" class="btn btn-sm hover-primary text-primary"><i class="fa-solid fa-history"></i></a>
     {%- endif %}

--- a/_includes/github-buttons.html
+++ b/_includes/github-buttons.html
@@ -11,7 +11,11 @@
     <a role="button" data-bs-toggle="tooltip" title="Report an issue" href="{{site.github.repository_url}}/issues/new?title={{'Issue on page: ' | url_encode }}{{page.title | url_encode }}&amp;body={{'I would like to report an issue on the ' | url_encode }}{{page.title | url_encode }}{{' page at `'| url_encode }}{{page.url | url_encode }}{{'`. Description of the issue:' | url_encode }}" class="btn btn-sm hover-primary text-primary"><i class="fa-solid fa-exclamation"></i></a>
     {%- endif %}
     {%- if site.theme_variables.github_buttons.history or site.theme_variables.github_buttons.history == nil %}
+    {%- if page.custom-editme %}
+    <a role="button" data-bs-toggle="tooltip" title="Check out the history of this page" href="{{site.github.repository_url}}/commits/{{site.github.source.branch}}/{{page.custom-editme}}" class="btn btn-sm hover-primary text-primary"><i class="fa-solid fa-history"></i></a>
+    {%- else %}
     <a role="button" data-bs-toggle="tooltip" title="Check out the history of this page" href="{{site.github.repository_url}}/commits/{{site.github.source.branch}}/{{page.path}}" class="btn btn-sm hover-primary text-primary"><i class="fa-solid fa-history"></i></a>
+    {%- endif %}
     {%- endif %}
 </div>
 {%- endif %}

--- a/pages/documentation/page_mechanics.md
+++ b/pages/documentation/page_mechanics.md
@@ -29,7 +29,7 @@ title: Title of the page
 
 * `hide_sidebar`: When true, the sidebar will be hided. Default: false
 
-* `custom-editme`: This attribute can be used to specify an alternative file/link when clicked on the edit-me button
+* `custom-editme`: This attribute can be used to specify an alternative file when clicked on the edit-me or history button. Example: _data/news.yml
 
 * `keywords`: List here all the keywords that can be used to find the page using the searchbox in the right upper corner of the page, lowercase.
 

--- a/pages/documentation/page_mechanics.md
+++ b/pages/documentation/page_mechanics.md
@@ -29,7 +29,7 @@ title: Title of the page
 
 * `hide_sidebar`: When true, the sidebar will be hided. Default: false
 
-* `custom-editme`: This attribute can be used to specify an alternative file when clicked on the edit-me or history button. Example: _data/news.yml
+* `custom_editme`: This attribute can be used to specify an alternative file when clicked on the edit-me or history button. Example: _data/news.yml
 
 * `keywords`: List here all the keywords that can be used to find the page using the searchbox in the right upper corner of the page, lowercase.
 

--- a/pages/example_pages/news.md
+++ b/pages/example_pages/news.md
@@ -1,6 +1,7 @@
 ---
 title: News
 toc: false
+custom_editme: _data/news.yml
 ---
 
 


### PR DESCRIPTION
This will close #83 . 

The open an issue button does not get changed for now, since it is confusing that the issue is talking about something different than what is seen on the website.