### PR TITLE
New option to make TOC full width

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -55,6 +55,7 @@ theme_variables:
   #   open_issue: true
   #   history: true
   # toc:
+  #   full_width: false
   #   min_headers: 2
   #   headers: 'h2'
   # topnav:

--- a/_includes/toc.html
+++ b/_includes/toc.html
@@ -3,6 +3,11 @@
     $('#toc').toc({ minimumHeaders: {{site.theme_variables.toc.min_headers | default: 2 }}, listType: 'ul', noBackToTopLinks: true, showSpeed: 0, headers: '{{site.theme_variables.toc.headers | default: 'main h2' }}' , title: '', classes:{toc:'p-3 rounded my-4'} });
   });
 </script>
+{%- assign col = site.theme_variables.toc.full_width %}
+{%- unless col %}
 <div class="col-12 col-sm-7 col-xl-5">
+{%- endunless  %}
   <div id="toc"></div>
+{%- unless col %}
 </div>
+{%- endunless  %}

--- a/pages/documentation/configuring_theme.md
+++ b/pages/documentation/configuring_theme.md
@@ -47,6 +47,7 @@ theme_variables:
     open_issue: true
     history: true
   toc:
+    full_width: false
     min_headers: 2
     headers: 'h2'
   topnav:
@@ -70,6 +71,7 @@ More detailed information about these settings can be found here:
   * `open_issue`: Enable the 'open an issue on this page' button.
   * `history`: Enable the 'history of this page' button.
 * toc: Settings related to the table of contents.
+  * `full_width`: Show the table of contents as a box that spans the full width of the screen. Default is **false**
   * `min_headers`: The minimum amount of headers (h2, h3,.. depending on the headers option) on a page for the toc to appear. This has to be an integer.
   * `headers`: The type of headers that need to be indexed by the toc. This can be a list or one value, ex: **'h1, h2, h3'** or **'h2'**
 * topnav: Settings related to the top navigation.


### PR DESCRIPTION
A new option in the config file is added to make full width table of contents. Default is `false`.

```yml
theme_variables: 
  toc:
    full_width: false
```

This will close #167 

