### PR TITLE
Param to disable sorting in contributors

### DIFF
--- a/_includes/contributor-carousel-selection.html
+++ b/_includes/contributor-carousel-selection.html
@@ -33,7 +33,11 @@
 {%- endif %}
 {%- endfor %}
 {%- endif %}
+{%- unless include.sort == false %}
 {%- assign allcontributors = allcontrstr | split: ", " | uniq | sort %}
+{%- else %}
+{%- assign allcontributors = allcontrstr | split: ", " | uniq %}
+{%- endunless %}
 <div id="contributors-carousel" class="carousel carousel-dark slide my-4" data-ride="carousel" data-bs-interval="7000">
     <div class="carousel-inner">
     {%- assign counter = 0 %}

--- a/_includes/contributor-minitiles-page.html
+++ b/_includes/contributor-minitiles-page.html
@@ -2,7 +2,11 @@
 <span class="d-block h2-like fs-2">Contributors</span>
 <div class="p-4 rounded mt-4 page-contributors d-flex flex-wrap gap-2">
     {%- assign contributors = site.data.CONTRIBUTORS %}
+    {%- unless include.sort == false %}
     {%- assign page_contributors = page.contributors | sort %}
+    {%- else %}
+    {%- assign page_contributors = page.contributors %}
+    {%- endunless %}
     {%- for contributor in page_contributors %}
     {%- assign id = contributors[contributor].git | default: 'no_github' %}
     <div class="dropup-center dropup d-inline-block">

--- a/_includes/contributor-tiles-all.html
+++ b/_includes/contributor-tiles-all.html
@@ -33,7 +33,11 @@
 {%- endif %}
 {%- endfor %}
 {%- endif %}
+{%- unless include.sort == false %}
 {%- assign allcontributors = allcontrstr | split: ", " | uniq | sort %}
+{%- else %}
+{%- assign allcontributors = allcontrstr | split: ", " | uniq %}
+{%- endunless %}
 <div class="row row-cols-2 row-cols-sm-3 row-cols-md-4 row-cols-xl-{{nr}} g-4 contributor-cards">
   {%- for contributor in allcontributors %}
   <div class="col">

--- a/pages/example_pages/contributors.md
+++ b/pages/example_pages/contributors.md
@@ -21,16 +21,17 @@ Contributors are defined in two places: the page-metadata and the [CONTRIBUTORS.
 * `custom`: `, ` separated list of contributor names if you only want to show a specific collection of contributors.
 * `role`: specify the role of the contributors you want to filter on. This is not combinable with the custom list of contributors.
 * `nr`: give an integer to specify the number of columns/contributor cards per row.
+* `sort`: disable sorting of contributors by adding *false*. Default: *true*.
 
 ### Example with parameters
 
 ```
 {% raw %}
-{% include contributor-tiles-all.html custom="Bert Droesbeke, example contributor" nr=4 %}
+{% include contributor-tiles-all.html custom="Example Contributor, Bert Droesbeke" nr=4 sort=false %}
 {% endraw %}
 ```
 
-{% include contributor-tiles-all.html custom="Bert Droesbeke, example contributor" nr=4 %}
+{% include contributor-tiles-all.html custom="Example Contributor, Bert Droesbeke" nr=4 sort=false %}
 
 ## List website contributors in a carousel
 
@@ -49,13 +50,14 @@ Contributors are defined in two places: the page-metadata and the [CONTRIBUTORS.
 * `custom`: `, ` separated list of contributor names if you only want to show a specific collection of contributors.
 * `role`: specify the role of the contributors you want to filter on. This is not combinable with the custom list of contributors.
 * `nr`: give an integer to specify the number of columns/contributor cards per row.
+* `sort`: disable sorting of contributors by adding *false*. Default: *true*.
 
 ### Example with parameters
 
 ```
 {% raw %}
-{% include contributor-carousel-selection.html custom="Bert Droesbeke, example contributor" nr=4 %}
+{% include contributor-carousel-selection.html custom="Bert Droesbeke, Example Contributor" nr=4 %}
 {% endraw %}
 ```
 
-{% include contributor-carousel-selection.html custom="Bert Droesbeke, example contributor" nr=4 %}
+{% include contributor-carousel-selection.html custom="Bert Droesbeke, Example Contributor" nr=4 %}

--- a/pages/example_pages/general_page.md
+++ b/pages/example_pages/general_page.md
@@ -1,7 +1,7 @@
 ---
 title: General page example
 type: example_pages
-contributors: [Bert Droesbeke, Long example contributor , example contributor, example contributor, example contributor, example contributor, example contributor, example contributor, example contributor]
+contributors: [Bert Droesbeke, Long Example Contributor , Example Contributor, Example Contributor, Example Contributor, Example Contributor, Example Contributor, Example Contributor, Example Contributor]
 coordinators: [Bert Droesbeke] 
 description: This description is used when the page is listed
 page_id: gp1


### PR DESCRIPTION
Contributors in a grid or carousel can now be listed in a specific order. This will close #172 