### PR TITLE
Add ability to specify number of columns in the section navigation tiles

### DIFF
--- a/_includes/contributor-carousel-selection.html
+++ b/_includes/contributor-carousel-selection.html
@@ -1,5 +1,5 @@
 {%- assign contributors = site.data.CONTRIBUTORS %}
-{%- assign nr = include.nr | default: 5 %}
+{%- assign nr = include.col | default: 5 %}
 {%- if include.custom %}
 {%- assign allcontrstr = include.custom %}
 {%- elsif include.role %}

--- a/_includes/contributor-tiles-all.html
+++ b/_includes/contributor-tiles-all.html
@@ -1,5 +1,5 @@
 {%- assign contributors = site.data.CONTRIBUTORS %}
-{%- assign nr = include.nr | default: 5 %}
+{%- assign nr = include.col | default: 5 %}
 {%- if include.custom %}
 {%- assign allcontrstr = include.custom %}
 {%- elsif include.role %}

--- a/_includes/section-navigation-tiles-simple.html
+++ b/_includes/section-navigation-tiles-simple.html
@@ -1,6 +1,6 @@
 {%- assign allcountries = site.data.countries %}
 {%- assign except = include.except | split: ", " %}
-<div class="row row-cols-1 row-cols-md-2 g-3 my-4 navigation-tiles">
+<div class="row row-cols-1 row-cols-md-2 row-cols-lg-{{ include.col | default: 2 }} g-3 my-4 navigation-tiles">
     {%- for current_page in site.pages | sorted %}
     {%- if current_page.title and current_page.search_exclude != true and current_page.type == include.type %}
     {%- unless except contains current_page.name %}

--- a/_includes/section-navigation-tiles.html
+++ b/_includes/section-navigation-tiles.html
@@ -46,7 +46,7 @@
     {%- endunless %}
 </div>
 {%- endunless %}
-<div class="row row-cols-1 row-cols-md-2 g-4 mb-5 navigation-tiles">
+<div class="row row-cols-1 row-cols-md-2 row-cols-lg-{{ include.col | default: 2 }}  g-4 mb-5 navigation-tiles">
     {%- for current_page in site.pages | sorted %}
     {%- assign affiliations_classes = "" %}
     {%- assign related_pages_classes = "" %}

--- a/pages/example_pages/contributors.md
+++ b/pages/example_pages/contributors.md
@@ -20,17 +20,17 @@ Contributors are defined in two places: the page-metadata and the [CONTRIBUTORS.
 
 * `custom`: `, ` separated list of contributor names if you only want to show a specific collection of contributors.
 * `role`: specify the role of the contributors you want to filter on. This is not combinable with the custom list of contributors.
-* `nr`: give an integer to specify the number of columns/contributor cards per row.
+* `col`: give an integer to specify the number of columns/contributor cards per row. Default: 5.
 
 ### Example with parameters
 
 ```
 {% raw %}
-{% include contributor-tiles-all.html custom="Bert Droesbeke, example contributor" nr=4 %}
+{% include contributor-tiles-all.html custom="Bert Droesbeke, example contributor" col=4 %}
 {% endraw %}
 ```
 
-{% include contributor-tiles-all.html custom="Bert Droesbeke, example contributor" nr=4 %}
+{% include contributor-tiles-all.html custom="Bert Droesbeke, example contributor" col=4 %}
 
 ## List website contributors in a carousel
 
@@ -48,14 +48,14 @@ Contributors are defined in two places: the page-metadata and the [CONTRIBUTORS.
 
 * `custom`: `, ` separated list of contributor names if you only want to show a specific collection of contributors.
 * `role`: specify the role of the contributors you want to filter on. This is not combinable with the custom list of contributors.
-* `nr`: give an integer to specify the number of columns/contributor cards per row.
+* `col`: give an integer to specify the number of columns/contributor cards per row. Default: 5.
 
 ### Example with parameters
 
 ```
 {% raw %}
-{% include contributor-carousel-selection.html custom="Bert Droesbeke, example contributor" nr=4 %}
+{% include contributor-carousel-selection.html custom="Bert Droesbeke, example contributor" col=4 %}
 {% endraw %}
 ```
 
-{% include contributor-carousel-selection.html custom="Bert Droesbeke, example contributor" nr=4 %}
+{% include contributor-carousel-selection.html custom="Bert Droesbeke, example contributor" col=4 %}

--- a/pages/example_pages/overview_tiles.md
+++ b/pages/example_pages/overview_tiles.md
@@ -21,7 +21,8 @@ Becomes:
 
 * `affiliations`: Turn on filtering by affiliation (`true` or `false`)
 * `search`: enable search in the tiles (`true` or `false`)
-* `except`: `, ` separated list of page file names which should be excluded, including the file extension
+* `except`: `, ` separated list of page file names which should be excluded, including the file extension.
+* `col`: give an integer to specify the number of columns/section cards per row. Default: 2.
 
 
 ## Section tiles simple
@@ -37,5 +38,6 @@ Becomes:
 
 ### Parameters
 
-* `except`: `, ` separated list of page names which should be excluded, including the file extension
+* `except`: `, ` separated list of page names which should be excluded, including the file extension.
+* `col`: give an integer to specify the number of columns/section cards per row. Default: 2.
 


### PR DESCRIPTION
* `col`: give an integer to specify the number of columns/section cards per row. Default: 2.

Example:
```
{% include section-navigation-tiles.html type="example_pages" affiliations=true search=true except="index.md" col=3 %}
```
or for the simple navigation tiles: 
```
{% include section-navigation-tiles-simple.html type="example_pages" col=3 %}
```

**IMPORTANT. The columns in contributor tiles are from now on specified with the `col` parameter, similar to the section navigation tiles.**