### PR TITLE
h1 css fix + better scroll spy

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -1,7 +1,7 @@
 <!doctype html>
 <html lang="en">
 {% include head.html %}
-<body class="d-flex flex-column min-vh-100">
+<body class="d-flex flex-column min-vh-100" data-bs-spy="scroll" data-bs-target="#toc-contents" data-bs-smooth-scroll="true" tabindex="0">
     {% if jekyll.environment == "development" %}{% include dev-info.html %}{% endif %}
     {% include topnav.html %}
     <!-- Page Content -->

--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -22,7 +22,7 @@ layout: default
     <div id="toc" class="text-muted sticky-lg-top">
         {%- include toc.html %}
     </div>
-    <div id="content" class="mb-5" data-bs-spy="scroll" data-bs-target="#toc-contents" data-bs-smooth-scroll="true" tabindex="0">
+    <div id="content" class="mb-5">
         {{content}}
         {% include resource-table-page.html %}
         {% include related-pages.html %}

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -28,7 +28,7 @@ $container-max-widths: map-merge($container-max-widths, $custom-container-max-wi
 
 /*-----General styling-----*/
 
-#content {
+#main {
     h1 {
         font-family: $font-family-theme;
         font-weight: 400;


### PR DESCRIPTION
- [x] It is better to have the scroll spy on in the <body> object.
- [x] Make sure the css styling does apply on the h1 title too
