### PR TITLE
Add custom listing and sort toggle to overview tiles

### DIFF
--- a/_includes/contributor-carousel-selection.html
+++ b/_includes/contributor-carousel-selection.html
@@ -33,10 +33,9 @@
 {%- endif %}
 {%- endfor %}
 {%- endif %}
-{%- unless include.sort == false %}
-{%- assign allcontributors = allcontrstr | split: ", " | uniq | sort %}
-{%- else %}
 {%- assign allcontributors = allcontrstr | split: ", " | uniq %}
+{%- unless include.sort == false %}
+{%- assign allcontributors = allcontributors | sort %}
 {%- endunless %}
 <div id="contributors-carousel" class="carousel carousel-dark slide my-4" data-ride="carousel" data-bs-interval="7000">
     <div class="carousel-inner">

--- a/_includes/contributor-minitiles-page.html
+++ b/_includes/contributor-minitiles-page.html
@@ -2,10 +2,9 @@
 <span class="d-block h2-like fs-2">Contributors</span>
 <div class="p-4 rounded mt-4 page-contributors d-flex flex-wrap gap-2">
     {%- assign contributors = site.data.CONTRIBUTORS %}
-    {%- unless include.sort == false %}
-    {%- assign page_contributors = page.contributors | sort %}
-    {%- else %}
     {%- assign page_contributors = page.contributors %}
+    {%- unless include.sort == false %}
+    {%- assign page_contributors = page_contributors | sort %}
     {%- endunless %}
     {%- for contributor in page_contributors %}
     {%- assign id = contributors[contributor].git | default: 'no_github' %}

--- a/_includes/contributor-tiles-all.html
+++ b/_includes/contributor-tiles-all.html
@@ -33,10 +33,9 @@
 {%- endif %}
 {%- endfor %}
 {%- endif %}
-{%- unless include.sort == false %}
-{%- assign allcontributors = allcontrstr | split: ", " | uniq | sort %}
-{%- else %}
 {%- assign allcontributors = allcontrstr | split: ", " | uniq %}
+{%- unless include.sort == false %}
+{%- assign allcontributors = allcontributors | sort %}
 {%- endunless %}
 <div class="row row-cols-2 row-cols-sm-3 row-cols-md-4 row-cols-xl-{{nr}} g-4 contributor-cards">
   {%- for contributor in allcontributors %}

--- a/_includes/section-navigation-tiles.html
+++ b/_includes/section-navigation-tiles.html
@@ -47,11 +47,29 @@
 </div>
 {%- endunless %}
 <div class="row row-cols-1 row-cols-md-2 row-cols-lg-{{ include.col | default: 2 }}  g-4 mb-5 navigation-tiles">
-    {%- for current_page in site.pages | sorted %}
+    {%- if include.custom %}
+    {%- assign related_pages = include.custom | split: ", " %}
+    {%- unless include.sort == false %}
+    {%- assign related_pages = related_pages | sort %}
+    {%- endunless %}
+    {%- elsif include.type %}
+    {%- assign related_pages = site.pages | where:"type", include.type %}
+    {%- else %}
+    {%- assign related_pages = site.pages %}
+    {%- endif %}
+    {%- unless include.sort == false %}
+    {%- assign related_pages = related_pages | sort: 'title'%}
+    {%- endunless %}
+    {%- for related_page in related_pages %}
+    {%- if include.custom %}
+    {%- assign current_page = site.pages | where:"page_id", related_page | first %}
+    {%- else %}
+    {%- assign current_page = related_page %}
+    {%- endif %}
     {%- assign affiliations_classes = "" %}
     {%- assign related_pages_classes = "" %}
     {%- assign except = include.except | split: ", " %}
-    {%- if current_page.title and current_page.search_exclude != true and current_page.type == include.type %}
+    {%- if current_page.title and current_page.search_exclude != true %}
     {%- unless except contains current_page.name %}
     {%- if current_page.affiliations %}
     {%- capture affiliations_classes -%}

--- a/pages/documentation/website_sections.md
+++ b/pages/documentation/website_sections.md
@@ -21,9 +21,23 @@ Becomes:
 ### Parameters
 
 * `affiliations`: Turn on filtering by affiliation (`true` or `false`)
+* `type`: specify the tiles that are being shown by giving a page type (complimentary to custom).
 * `search`: enable search in the tiles (`true` or `false`)
 * `except`: `, ` separated list of page file names which should be excluded, including the file extension.
 * `col`: give an integer to specify the number of columns/section cards per row. Default: 2.
+* `sort`: disable sorting of contributors by adding *false*. Default: *true*.
+* `custom`: `, ` separated list of page_id's if you only want to show specific pages.
+
+
+## Section tiles using the custom parameter and without sorting
+
+```
+{% raw %}
+{% include section-navigation-tiles.html custom="gp3, gp2" sort=false %}
+{% endraw %}
+```
+
+{% include section-navigation-tiles.html custom="gp3, gp2" sort=false %}
 
 
 ## Section tiles simple


### PR DESCRIPTION
Section navigation tiles will now have following parameters:

* `affiliations`: Turn on filtering by affiliation (`true` or `false`)
* `type`: specify the tiles that are being shown by giving a page type (complimentary to custom).
* `search`: enable search in the tiles (`true` or `false`)
* `except`: `, ` separated list of page file names which should be excluded, including the file extension.
* `col`: give an integer to specify the number of columns/section cards per row. Default: 2.
* `sort`: disable sorting of contributors by adding *false*. Default: *true*.
* `custom`: `, ` separated list of page_id's if you only want to show specific pages.

These parameters are more in line with the ones of contributors. This will close #196 
