### PR TITLE
Fix topnav highlight bug when toc: false

### DIFF
--- a/_data/topnav.yml
+++ b/_data/topnav.yml
@@ -1,7 +1,7 @@
 ## Topnav single links
 ## if you want to list an external url, use external_url instead of url. the theme will apply a different link base.
 subitems:
-- title: Home
+- title: Main
   url: /
 - title: About
   url: /about

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -52,7 +52,7 @@
     <script src="{{ 'assets/js/lunr.min.js' | relative_url }}"></script>
     <script src="{{ 'assets/js/bootstrap.bundle.min.js' | relative_url }}"></script>
     <script src="{{ 'assets/js/anchor.min.js' | relative_url }}"></script>
-    <script src="{{ 'assets/js/toc.js' | relative_url }}"></script>
+    {% unless page.toc == false %}<script src="{{ 'assets/js/toc.js' | relative_url }}"></script>{% endunless %}
     <script src="{{ 'assets/js/jquery.navgoco.js' | relative_url }}"></script>
     <script src="{{ 'assets/js/main.js' | relative_url }}"></script>
     <script src="{{ 'assets/js/search.js' | relative_url }}"></script>

--- a/_includes/toc.html
+++ b/_includes/toc.html
@@ -1,4 +1,3 @@
-{%- unless page.toc == false %}
 <script>
   $(document).ready(function () {
     $('#toc-contents').toc({ minimumHeaders: {{site.theme_variables.toc.min_headers | default: 2 }}, listType: 'ul', classes: { list: 'list-unstyled' }, noBackToTopLinks: true, showSpeed: 0, headers: '{{site.theme_variables.toc.headers | default: 'main h2' }}' , title: '<strong class="my-2">On this page</strong><hr class="my-2">' });
@@ -8,4 +7,3 @@
   <i class="fa-solid fa-up-right-and-down-left-from-center me-2"></i>On this page
 </button>
 <nav id="toc-contents" class="collapse" aria-label="Table of contents"></nav>
-{%- endunless %}

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -1,7 +1,7 @@
 <!doctype html>
 <html lang="en">
 {% include head.html %}
-<body class="d-flex flex-column min-vh-100" data-bs-spy="scroll" data-bs-target="#toc-contents" data-bs-smooth-scroll="true" tabindex="0">
+<body class="d-flex flex-column min-vh-100"{% unless page.toc == false %} data-bs-spy="scroll" data-bs-target="#toc-contents" data-bs-smooth-scroll="true" tabindex="0"{% endunless %}>
     {% if jekyll.environment == "development" %}{% include dev-info.html %}{% endif %}
     {% include topnav.html %}
     <!-- Page Content -->

--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -19,9 +19,11 @@ layout: default
         <div class="summary">{{page.summary}}</div>
         {%- endif %}
     </div>
+    {%- unless page.toc == false %}
     <div id="toc" class="text-muted sticky-xl-top">
         {%- include toc.html %}
     </div>
+    {%- endunless %}
     <div id="content" class="mb-5">
         {{content}}
         {% include resource-table-page.html %}

--- a/pages/example_pages/general_page_4.md
+++ b/pages/example_pages/general_page_4.md
@@ -3,6 +3,7 @@ title: General page example 4
 type: example_pages
 description: This page has no more information
 page_id: gp4
+toc: false
 ---
 
 Lorem ipsum dolor sit amet, consectetur adipiscing elit. Etiam quis fermentum velit, at vulputate sapien. Suspendisse efficitur id elit sed volutpat. Etiam luctus sem id finibus pulvinar. Morbi sit amet purus a velit pretium imperdiet ut et elit. Maecenas eleifend, urna a aliquam lobortis, erat ligula efficitur velit, aliquam accumsan odio turpis nec nibh. Suspendisse placerat porttitor neque, vitae consequat massa aliquam eu. Aliquam erat volutpat. Class aptent taciti sociosqu ad litora torquent per conubia nostra, per inceptos himenaeos. Proin sed velit vitae tellus egestas condimentum. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia curae; Mauris pretium scelerisque dignissim. Maecenas ipsum nisl, pretium non mollis ac, varius pulvinar nibh. Donec venenatis pulvinar arcu, vitae interdum purus dictum in. Proin sed tempus mi.


### PR DESCRIPTION
The scrollspy being enabled on body was messing around with the top nav active element when `toc: false` in the frontmatter. This will close #207 