### PR TITLE
Add support for custom headings

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -59,9 +59,15 @@ theme_variables:
   #   edit_me: true
   #   open_issue: true
   #   history: true
+  # headings:
+  #   related-pages: Related pages
+  #   more-information-tiles: More information
+  #   resource-table-all: Tools and resources on this page
+  #   affiliation-tiles-page: Affiliations
+  #   contributor-minitiles-page: Contributors
   # toc:
-  #   min_headers: 2
-  #   headers: 'h2'
+  #   min_headings: 2
+  #   headings: 'h2'
   # topnav:
     # theme: light
     # brand_logo: assets/img/main_logo.svg

--- a/_includes/affiliation-tiles-page.html
+++ b/_includes/affiliation-tiles-page.html
@@ -1,5 +1,5 @@
 {%- if page.affiliations and page.affiliations.size != 0 %}
-<span class="d-block h2-like fs-2">Affiliations</span>
+<span class="d-block h2-like fs-2">{{site.theme_variables.headings.affiliation-tiles-page | default: 'Affiliations' }}</span>
 <div class="mt-4 d-flex flex-wrap gap-2">
     {%- assign affiliations = site.data.affiliations %}
     {%- assign page_affiliations = page.affiliations | sort %}

--- a/_includes/contributor-minitiles-page.html
+++ b/_includes/contributor-minitiles-page.html
@@ -1,5 +1,5 @@
 {%- if page.contributors and page.contributors.size != 0 %}
-<span class="d-block h2-like fs-2">Contributors</span>
+<span class="d-block h2-like fs-2">{{site.theme_variables.headings.more-information-tiles | default: 'Contributors' }}</span>
 <div class="p-4 rounded mt-4 page-contributors d-flex flex-wrap gap-2">
     {%- assign contributors = site.data.CONTRIBUTORS %}
     {%- assign page_contributors = page.contributors %}

--- a/_includes/more-information-tiles.html
+++ b/_includes/more-information-tiles.html
@@ -40,7 +40,7 @@
 {%- endif %}
 {%- if actual_training or actual_faircookbook or actual_fairsharing or actual_dsw or actual_rdmkit %}
 <!-- More information -->
-<h2>More information</h2>
+<h2>{{site.theme_variables.headings.more-information-tiles | default: 'More information' }}</h2>
 
 <div class="row row-cols-1 row-cols-md-2 g-4 mt-2">
     {%- if actual_training %}

--- a/_includes/related-pages.html
+++ b/_includes/related-pages.html
@@ -6,7 +6,7 @@
 {%- endfor %}
 {%- if actual_related != nil %}
 <!-- Read next -->
-<h2>Related pages</h2>
+<h2>{{site.theme_variables.headings.related-pages | default: 'Related pages' }}</h2>
 
 <div class="row row-cols-1 row-cols-md-2 g-4 mt-2">
     {%- if page.related_pages %}

--- a/_includes/resource-table-all.html
+++ b/_includes/resource-table-all.html
@@ -6,7 +6,7 @@
 {%- assign country_pages = site.pages | where_exp: "item", "item.search_exclude != true" | where_exp:"item","item.national_resources != nil" %}
 {%- unless tools.size == 0 or tools == nil %}
 {%- if include.tag %}
-<h2>Tools and resources on this page</h2>
+<h2>{{site.theme_variables.headings.resource-table-all | default: 'Tools and resources on this page' }}</h2>
 {%- endif %}
 <a class="visually-hidden-focusable" href='#skip-tool-table'>Skip tool table</a>
 <div class="table-responsive mt-4 mb-5">

--- a/_includes/resource-table-all.html
+++ b/_includes/resource-table-all.html
@@ -6,17 +6,14 @@
 {%- assign country_pages = site.pages | where_exp: "item", "item.search_exclude != true" | where_exp:"item","item.national_resources != nil" %}
 {%- unless tools.size == 0 or tools == nil %}
 {%- if include.tag %}
-<h2>Relevant tools and resources</h2>
+<h2>Tools and resources on this page</h2>
 {%- endif %}
 <a class="visually-hidden-focusable" href='#skip-tool-table'>Skip tool table</a>
 <div class="table-responsive mt-4 mb-5">
     <table class="tooltable table display">
         <thead>
             <tr class="text-nowrap">
-                <th>Tool or resource {%- if include.tag -%}
-                    <a data-bs-toggle="tooltip" data-bs-original-title="This is a curated list which means that not all tools or resources that exist for this topic are listed here. This is mainly because we do not intend to be a registry. In most cases you will only find back the tools or resources that are mentioned in this page.">
-                        <i class="fa-solid fa-info-circle"></i>
-                    </a>{%- endif %}
+                <th>Tool or resource
                 </th>
                 <th>Description</th>
                 <th>Related pages</th>

--- a/_includes/toc.html
+++ b/_includes/toc.html
@@ -1,6 +1,6 @@
 <script>
   $(document).ready(function () {
-    $('#toc-contents').toc({ minimumHeaders: {{site.theme_variables.toc.min_headers | default: 2 }}, listType: 'ul', classes: { list: 'list-unstyled' }, noBackToTopLinks: true, showSpeed: 0, headers: '{{site.theme_variables.toc.headers | default: 'main h2' }}' , title: '<strong class="my-2">On this page</strong><hr class="my-2">' });
+    $('#toc-contents').toc({ minimumHeaders: {{site.theme_variables.toc.min_headings | default: 2 }}, listType: 'ul', classes: { list: 'list-unstyled' }, noBackToTopLinks: true, showSpeed: 0, headers: '{{site.theme_variables.toc.headings | default: 'main h2' }}' , title: '<strong class="my-2">On this page</strong><hr class="my-2">' });
   });
 </script>
 <button id="btn-toc-hide" class="btn bg-light d-xl-none hover-primary mb-3" type="button" data-bs-toggle="collapse" data-bs-target="#toc-contents" aria-expanded="true" aria-controls="toc-contents">

--- a/pages/documentation/configuring_theme.md
+++ b/pages/documentation/configuring_theme.md
@@ -46,10 +46,16 @@ theme_variables:
     edit_me: true
     open_issue: true
     history: true
+  headings:
+    related-pages: Related pages
+    more-information-tiles: More information
+    resource-table-all: Tools and resources on this page
+    affiliation-tiles-page: Affiliations
+    contributor-minitiles-page: Contributors
   toc:
     full_width: false
-    min_headers: 2
-    headers: 'h2'
+    min_headings: 2
+    headings: 'h2'
   topnav:
     theme: light
     brand_logo: assets/img/main_logo.svg
@@ -70,9 +76,15 @@ More detailed information about these settings can be found here:
   * `edit_me`: Enable the 'propose an edit on this page' button.
   * `open_issue`: Enable the 'open an issue on this page' button.
   * `history`: Enable the 'history of this page' button.
+* headings: Change the subtitles of the page sections that are automatically generated
+    `related-pages`: Default: Related pages
+    `more-information-tiles`: Default: More information
+    `resource-table-all`: Default: Tools and resources on this page
+    `affiliation-tiles-page`: Default: Affiliations
+    `contributor-minitiles-page`: Default: Contributors
 * toc: Settings related to the table of contents.
-  * `min_headers`: The minimum amount of headers (h2, h3,.. depending on the headers option) on a page for the toc to appear. This has to be an integer.
-  * `headers`: The type of headers that need to be indexed by the toc. This can be a list or one value, ex: **'h1, h2, h3'** or **'h2'**
+  * `min_headings`: The minimum amount of headings (h2, h3,.. depending on the headings option) on a page for the toc to appear. This has to be an integer.
+  * `headings`: The type of headings that need to be indexed by the toc. This can be a list or one value, ex: **'h1, h2, h3'** or **'h2'**
 * topnav: Settings related to the top navigation.
   *  `theme`: This variable is needed to change between a dark and a light top navigation. possible values: **dark** and **light**
   *  `brand_logo`: Custom path towards the brand logo, in case the assets/img/main_logo.svg can not be used.

--- a/pages/documentation/configuring_theme.md
+++ b/pages/documentation/configuring_theme.md
@@ -53,7 +53,6 @@ theme_variables:
     affiliation-tiles-page: Affiliations
     contributor-minitiles-page: Contributors
   toc:
-    full_width: false
     min_headings: 2
     headings: 'h2'
   topnav:


### PR DESCRIPTION
  We introduce new variables in the config file that allows the user to edit the headings that are currently automatically generated based on the content and metadata of a page. 
  
  The defaults and variables are listed here:

```yml
theme_variables: 
  headings:
    related-pages: Related pages
    more-information-tiles: More information
    resource-table-all: Tools and resources on this page
    affiliation-tiles-page: Affiliations
    contributor-minitiles-page: Contributors
```   

## :rotating_light:  **BREAKING** :rotating_light: 

The variables to specify the min of headings that need to appear for the table of contents to show up and what type it has to pick up is changed from `headers` -> `headings` to be consistent and more correct.
```yml
theme_variables: 
  toc:
    min_headings: 2
    headings: 'h2'
```