### PR TITLE
Support for Matomo Website ID

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -15,6 +15,8 @@ gtag:
 
 matomo:
 # Matomo domain where Matomo is running
+matomo_id:
+# Integer indicating the Matomo Website ID
 
 plausible: 
 # Plausible tag

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -114,12 +114,13 @@
         _paq.push(['trackPageView']);
         _paq.push(['enableLinkTracking']);
         (function() {
-            var u="{{site.matomo}}";
-            _paq.push(['setTrackerUrl', u+'piwik.php']);
-            _paq.push(['setSiteId', '2']);
-            var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
-            g.async=true; g.src=u+'piwik.js'; s.parentNode.insertBefore(g,s);
+        var u="{{site.matomo}}";
+        _paq.push(['setTrackerUrl', u+'matomo.php']);
+        _paq.push(['setSiteId', '1']);
+        var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
+        g.async=true; g.src=u+'matomo.js'; s.parentNode.insertBefore(g,s);
         })();
     </script>
+    <!-- End Matomo Code -->
     {%- endif %}
 </head>

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -116,7 +116,7 @@
         (function() {
         var u="{{site.matomo}}";
         _paq.push(['setTrackerUrl', u+'matomo.php']);
-        _paq.push(['setSiteId', '1']);
+        _paq.push(['setSiteId', '{{site.matomo_id}}']);
         var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
         g.async=true; g.src=u+'matomo.js'; s.parentNode.insertBefore(g,s);
         })();

--- a/pages/documentation/configuring_theme.md
+++ b/pages/documentation/configuring_theme.md
@@ -24,6 +24,8 @@ gtag:
 
 matomo:
 # Matomo domain where Matomo is running
+matomo_id:
+# Integer indicating the Matomo Website ID
 
 plausible: 
 # Plausible tag


### PR DESCRIPTION
New attribute in _config.yml:

```yml
matomo:
# Matomo domain where Matomo is running
matomo_id:
# Integer indicating the Matomo Website ID
```