### PR TITLE
Bug fix: data tables can not be used when national resources are present

### DIFF
--- a/_includes/resource-table-all.html
+++ b/_includes/resource-table-all.html
@@ -93,7 +93,10 @@
             {%- endfor %}
             {%- unless total_county_tools == 0 or include.tag == nil %}
             <tr class="collapse multi-collapse table-light" id="resource_title">
-                <td colspan="4"><b>National resources</b></td>
+                <td><b>National resources</b></td>
+                <td></td>
+                <td></td>
+                <td></td>
             </tr>
             {%- endunless %}
             {%- assign hide_ids = "resource_title" %}


### PR DESCRIPTION
Because the National resources row only contained one cell, it could not order the table.