### PR TITLE
Fix + test for long tool names

### DIFF
--- a/_data/tool_and_resource_list.yml
+++ b/_data/tool_and_resource_list.yml
@@ -48,7 +48,7 @@
     API framework and data model for cross-cohort searching.
   url: https://github.com/ga4gh-beacon/beacon-v2
   id: beacon
-  name: Beacon v2
+  name: Beacon v2 with a very long name + description
   registry:
     fairsharing: 6fba91
     europmc: 35297548

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -796,7 +796,6 @@ footer {
 
 .tool {
     cursor: pointer;
-    white-space: nowrap;
     color: $link-color;
     background-color: rgba($link-color, 0.05);
     border-radius: $border-radius;
@@ -807,7 +806,11 @@ footer {
         color: $primary;
     }
 }
-
+@include media-breakpoint-up(sm) {
+    .tool {
+        white-space: nowrap;
+    }
+}
 .popover-tool {
     max-width: 20rem;
 


### PR DESCRIPTION
When the tool name is long, it tended to break through the screen view width. Closes #231 