### PR TITLE
Keep track of GitHub stats

### DIFF
--- a/.github/workflows/stats.yml
+++ b/.github/workflows/stats.yml
@@ -6,13 +6,9 @@ on:
     # Run every Monday at 00:00 UTC
     - cron: '0 0 * * 1'
 
-
-permissions: write-all
-
 jobs:
   update-stats:
     runs-on: ubuntu-latest
-
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v2
@@ -23,7 +19,7 @@ jobs:
           # Fetch GitHub stats using API
           curl -L \
             -H "Accept: application/vnd.github+json" \
-            -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
+            -H "Authorization: Bearer ${{ secrets.USER_TOKEN }}" \
             -H "X-GitHub-Api-Version: 2022-11-28" \
             https://api.github.com/repos/ELIXIR-Belgium/elixir-toolkit-theme/traffic/clones > clones-stats.json
           cat clones-stats.json
@@ -33,7 +29,7 @@ jobs:
         run: |
           curl -L \
             -H "Accept: application/vnd.github+json" \
-            -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
+            -H "Authorization: Bearer ${{ secrets.USER_TOKEN }}" \
             -H "X-GitHub-Api-Version: 2022-11-28" \
             https://api.github.com/repos/ELIXIR-Belgium/elixir-toolkit-theme/traffic/views > views-stats.json
           cat views-stats.json

--- a/.github/workflows/stats.yml
+++ b/.github/workflows/stats.yml
@@ -14,25 +14,36 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@v2
 
-      - name: Fetch GitHub Stats
-        id: fetch-stats
+      - name: Fetch GitHub Stats Clones
+        id: fetch-clones
         run: |
           # Fetch GitHub stats using API
-          # Modify this script to suit your needs
-          # Example: Use curl to fetch stats
-          curl -H "Accept: application/vnd.github.v3+json" \
-               -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
-               https://api.github.com/repos/elixir-toolkit-theme/traffic/clones > stats.json
+          curl -L \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            https://api.github.com/repos/ELIXIR-Belgium/elixir-toolkit-theme/traffic/clones > clones-stats.json
+
+      - name: Fetch GitHub Stats Views
+        id: fetch-views
+        run: |
+          curl -L \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            https://api.github.com/repos/ELIXIR-Belgium/elixir-toolkit-theme/traffic/views > views-stats.json
+
 
       - name: Update Stats File
         run: |
-          # Parse stats.json and update the stats file
-          # Modify this script to parse and update the stats file
-          # Example: Use jq to parse JSON and update a stats file
-          jq -r '.clones' stats.json > clones.txt
-          jq -r '.count' stats.json > count.txt
-          echo "Clones: $(cat clones.txt)" > stats.txt
-          echo "Count: $(cat count.txt)" >> stats.txt
+          CLONES=$(jq -r '.clones | .[] | .count' clones-stats.json)
+          UNIQUECLONES=$(jq -r '.clones | .[] | .uniques' clones-stats.json)
+          VIEWS=$(jq -r '.clones | .[] | .count' views-stats.json)
+          UNIQUEVIEWS=$(jq -r '.clones | .[] | .uniques' views-stats.json)
+          DATE=$(date +'%Y-%m-%d %H:%M:%S')
+          echo "Date,Clones,Unique Clones,Views,Unique Views" > stats.csv
+          echo "$DATE,$CLONES,$UNIQUECLONES,$VIEWS,$UNIQUEVIEWS"
+
 
       - name: Commit and Push Changes
         uses: EndBug/add-and-commit@v7

--- a/.github/workflows/stats.yml
+++ b/.github/workflows/stats.yml
@@ -2,9 +2,9 @@ name: Update Weekly GitHub Stats
 
 on:
   workflow_dispatch:
+  # Run every 2 weeks on Monday at 00:00 UTC
   schedule:
-    # Run every Monday at 00:00 UTC
-    - cron: '0 0 * * 1'
+    - cron: '0 0 * * 1/2'
 
 jobs:
   update-stats:
@@ -19,7 +19,7 @@ jobs:
           # Fetch GitHub stats using API
           curl -L \
             -H "Accept: application/vnd.github+json" \
-            -H "Authorization: Bearer ${{ secrets.PERSONAL_TOKEN }}" \
+            -H "Authorization: Bearer ${{ secrets.STATS_TOKEN }}" \
             -H "X-GitHub-Api-Version: 2022-11-28" \
             https://api.github.com/repos/ELIXIR-Belgium/elixir-toolkit-theme/traffic/clones > clones-stats.json
           cat clones-stats.json
@@ -29,7 +29,7 @@ jobs:
         run: |
           curl -L \
             -H "Accept: application/vnd.github+json" \
-            -H "Authorization: Bearer ${{ secrets.PERSONAL_TOKEN }}" \
+            -H "Authorization: Bearer ${{ secrets.STATS_TOKEN }}" \
             -H "X-GitHub-Api-Version: 2022-11-28" \
             https://api.github.com/repos/ELIXIR-Belgium/elixir-toolkit-theme/traffic/views > views-stats.json
           cat views-stats.json
@@ -43,7 +43,7 @@ jobs:
           UNIQUEVIEWS=$(jq '.uniques' views-stats.json)
           DATE=$(date +'%Y-%m-%d %H:%M:%S')
           echo "Date,Clones,Unique Clones,Views,Unique Views" > stats.csv
-          echo "$DATE,$CLONES,$UNIQUECLONES,$VIEWS,$UNIQUEVIEWS"
+          echo "$DATE,$CLONES,$UNIQUECLONES,$VIEWS,$UNIQUEVIEWS" >> stats.csv
 
 
       - name: Commit and Push Changes

--- a/.github/workflows/stats.yml
+++ b/.github/workflows/stats.yml
@@ -6,7 +6,8 @@ on:
     # Run every Monday at 00:00 UTC
     - cron: '0 0 * * 1'
 
-permissions: read-all
+
+permissions: write-all
 
 jobs:
   update-stats:

--- a/.github/workflows/stats.yml
+++ b/.github/workflows/stats.yml
@@ -36,10 +36,10 @@ jobs:
 
       - name: Update Stats File
         run: |
-          CLONES=$(jq -r '.clones | .[] | .count' clones-stats.json)
-          UNIQUECLONES=$(jq -r '.clones | .[] | .uniques' clones-stats.json)
-          VIEWS=$(jq -r '.clones | .[] | .count' views-stats.json)
-          UNIQUEVIEWS=$(jq -r '.clones | .[] | .uniques' views-stats.json)
+          CLONES=$(jq -r '.count' clones-stats.json)
+          UNIQUECLONES=$(jq -r '.uniques' clones-stats.json)
+          VIEWS=$(jq -r '.count' views-stats.json)
+          UNIQUEVIEWS=$(jq -r '.uniques' views-stats.json)
           DATE=$(date +'%Y-%m-%d %H:%M:%S')
           echo "Date,Clones,Unique Clones,Views,Unique Views" > stats.csv
           echo "$DATE,$CLONES,$UNIQUECLONES,$VIEWS,$UNIQUEVIEWS"

--- a/.github/workflows/stats.yml
+++ b/.github/workflows/stats.yml
@@ -19,7 +19,7 @@ jobs:
           # Fetch GitHub stats using API
           curl -L \
             -H "Accept: application/vnd.github+json" \
-            -H "Authorization: Bearer ${{ secrets.USER_TOKEN }}" \
+            -H "Authorization: Bearer ${{ secrets.PERSONAL_TOKEN }}" \
             -H "X-GitHub-Api-Version: 2022-11-28" \
             https://api.github.com/repos/ELIXIR-Belgium/elixir-toolkit-theme/traffic/clones > clones-stats.json
           cat clones-stats.json
@@ -29,7 +29,7 @@ jobs:
         run: |
           curl -L \
             -H "Accept: application/vnd.github+json" \
-            -H "Authorization: Bearer ${{ secrets.USER_TOKEN }}" \
+            -H "Authorization: Bearer ${{ secrets.PERSONAL_TOKEN }}" \
             -H "X-GitHub-Api-Version: 2022-11-28" \
             https://api.github.com/repos/ELIXIR-Belgium/elixir-toolkit-theme/traffic/views > views-stats.json
           cat views-stats.json

--- a/.github/workflows/stats.yml
+++ b/.github/workflows/stats.yml
@@ -6,6 +6,8 @@ on:
     # Run every Monday at 00:00 UTC
     - cron: '0 0 * * 1'
 
+permissions: read-all
+
 jobs:
   update-stats:
     runs-on: ubuntu-latest

--- a/.github/workflows/stats.yml
+++ b/.github/workflows/stats.yml
@@ -23,6 +23,7 @@ jobs:
             -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
             -H "X-GitHub-Api-Version: 2022-11-28" \
             https://api.github.com/repos/ELIXIR-Belgium/elixir-toolkit-theme/traffic/clones > clones-stats.json
+          cat clones-stats.json
 
       - name: Fetch GitHub Stats Views
         id: fetch-views
@@ -32,14 +33,15 @@ jobs:
             -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
             -H "X-GitHub-Api-Version: 2022-11-28" \
             https://api.github.com/repos/ELIXIR-Belgium/elixir-toolkit-theme/traffic/views > views-stats.json
+          cat views-stats.json
 
 
       - name: Update Stats File
         run: |
-          CLONES=$(jq -r '.count' clones-stats.json)
-          UNIQUECLONES=$(jq -r '.uniques' clones-stats.json)
-          VIEWS=$(jq -r '.count' views-stats.json)
-          UNIQUEVIEWS=$(jq -r '.uniques' views-stats.json)
+          CLONES=$(jq '.count' clones-stats.json)
+          UNIQUECLONES=$(jq '.uniques' clones-stats.json)
+          VIEWS=$(jq '.count' views-stats.json)
+          UNIQUEVIEWS=$(jq '.uniques' views-stats.json)
           DATE=$(date +'%Y-%m-%d %H:%M:%S')
           echo "Date,Clones,Unique Clones,Views,Unique Views" > stats.csv
           echo "$DATE,$CLONES,$UNIQUECLONES,$VIEWS,$UNIQUEVIEWS"
@@ -49,7 +51,7 @@ jobs:
         uses: EndBug/add-and-commit@v7
         with:
           message: "Update weekly GitHub stats"
-          add: "stats.txt stats.json"
+          add: "stats.csv"
           branch: stats
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This GitHub Actions pulls every two weeks information about clones and page views of this repo, using the GitHub API.