### PR TITLE
bugfix: add back compatibility for older versions of the sass-converter

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -140,4 +140,4 @@ DEPENDENCIES
   webrick (~> 1.8.1)
 
 BUNDLED WITH
-   2.2.16
+   2.2.33

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -891,7 +891,7 @@ li.past_event,
 }
 
 /*-----More information tiles-----*/
-
+// Main accordion style
 a.info-collapse {
     i {
         transition: transform .2s ease-in-out;
@@ -919,6 +919,7 @@ a.info-collapse[aria-expanded="true"]:last-of-type + .show {
     border-bottom: 1px solid $border-color;
 }
 
+// Collapsed content styling
 .info-card {
     .info-logo {
         max-width: 250px;

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -894,9 +894,7 @@ li.past_event,
 
 a.info-collapse {
     i {
-        transition-property: transform;
-        transition-duration: 0.2s;
-        transition-timing-function: ease-in-out;
+        transition: transform .2s ease-in-out;
         margin-right: $spacer;
     }
     h3 {

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -892,26 +892,32 @@ li.past_event,
 
 /*-----More information tiles-----*/
 
-.info-collapse {
-    transition: border-color 0.2s ease-in-out;
 
+// Add a bottom border to the last accordion.
+a.info-collapse[aria-expanded="false"]:last-of-type, 
+a.info-collapse[aria-expanded="true"]:last-of-type + .show {
+    border-bottom: 1px solid $border-color;
+}
+
+a.info-collapse {
     i {
-        transition-property: margin-right, transform;
+        transition-property: transform;
         transition-duration: 0.2s;
         transition-timing-function: ease-in-out;
         margin-right: $spacer;
     }
-
+    h3 {
+        transition: color .2s ease-in-out;
+    }
     &[aria-expanded="true"] {
-        border-color: color.scale($border-color, $lightness: -30%) !important;
         i {
             transform: rotate(180deg);
         }
     }
     &:hover {
-        border-color: color.scale($border-color, $lightness: -30%) !important;
-        i {
-            color: color.scale($link-color, $lightness: -20%) !important;
+        i,
+        h3 {
+            color: rgba($link-color, .8);
         }
     }
 }

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -892,13 +892,6 @@ li.past_event,
 
 /*-----More information tiles-----*/
 
-
-// Add a bottom border to the last accordion.
-a.info-collapse[aria-expanded="false"]:last-of-type, 
-a.info-collapse[aria-expanded="true"]:last-of-type + .show {
-    border-bottom: 1px solid $border-color;
-}
-
 a.info-collapse {
     i {
         transition-property: transform;
@@ -910,6 +903,9 @@ a.info-collapse {
         transition: color .2s ease-in-out;
     }
     &[aria-expanded="true"] {
+        &:last-of-type {
+            border-bottom: 1px solid $border-color;
+        }
         i {
             transform: rotate(180deg);
         }
@@ -917,9 +913,15 @@ a.info-collapse {
     &:hover {
         i,
         h3 {
-            color: rgba($link-color, .8);
+            color: rgba($link-color, .8)!important;
         }
     }
+}
+
+// Add a bottom border to the last accordion.
+a.info-collapse[aria-expanded="false"]:last-of-type, 
+a.info-collapse[aria-expanded="true"]:last-of-type + .show {
+    border-bottom: 1px solid $border-color;
 }
 
 .info-card {

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -903,9 +903,6 @@ a.info-collapse {
         transition: color .2s ease-in-out;
     }
     &[aria-expanded="true"] {
-        &:last-of-type {
-            border-bottom: 1px solid $border-color;
-        }
         i {
             transform: rotate(180deg);
         }


### PR DESCRIPTION
This makes sure that compatibility with GitHub Pages is maintained. Closes #244 