### PR TITLE
Add the class parameter to the image include section

### DIFF
--- a/pages/documentation/markdown_cheat_sheet.md
+++ b/pages/documentation/markdown_cheat_sheet.md
@@ -132,6 +132,7 @@ Make sure that you add the image to the `images` directory and give it an unders
 * `caption`: Text that will appear under the image
 * `inline`: if true this image can be used in a list
 * `max-width`: Max width in px or em
+* `class`: add a custom CSS class
 
 
 or using following markdown syntax:


### PR DESCRIPTION
There is an undocumented feature to add a custom class (or perhaps classes) when including an image.