### PR TITLE
Fix: Proposed workflow for deployment using GitHub Actions does not set Jekyll env 

### DIFF
--- a/.github/workflows/jekyll.yml
+++ b/.github/workflows/jekyll.yml
@@ -41,7 +41,7 @@ jobs:
           bundle exec jekyll build --baseurl "${{ steps.pages.outputs.base_path }}"
         env:
           PAGES_REPO_NWO: ${{ github.repository }}
-          JEKYLL_ENV: ${{ steps.name.outputs.jekyll_env }}
+          JEKYLL_ENV: production
           JEKYLL_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           JEKYLL_BUILD_BRANCH: ${{ github.ref_name }}
           JEKYLL_BASE_PATH: ${{ steps.pages.outputs.base_path }}


### PR DESCRIPTION
This meant that GA was not working when the example workflow is used.