### PR TITLE
Add smarter scroll back to top button

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -20,7 +20,7 @@
         </div>
     </div>
     {%- if site.theme_variables.back_to_top or site.theme_variables.back_to_top == nil %}
-    <button id="back-to-top" class="btn btn-primary rounded-3" type="button" aria-hidden="true" onclick="topFunction()">
+    <button id="back-to-top" class="btn btn-primary btn-sm rounded-pill" type="button" aria-hidden="true" onclick="topFunction()">
         <i class="fa-solid fa-arrow-up"></i>
     </button>
     {%- endif %}

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -617,19 +617,20 @@ footer {
 
 #back-to-top {
     position: fixed;
-    bottom: -50px;
-    right: $spacer;
+    height: 50px;
+    width: 50px;
+    bottom: -50px; /* Default hidden position */
+    right: 1rem; /* Adjust as needed */
     opacity: 0;
     overflow: hidden;
     z-index: 1000;
     font-size: 21px;
-    padding: 12px 20px;
     transition:
         bottom 0.15s ease-out,
         opacity 0.15s ease-out;
 
     &.visible {
-        bottom: $spacer;
+        bottom: 1rem; /* Initial visible position */
         opacity: 1;
     }
 }

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -620,17 +620,16 @@ footer {
     height: 50px;
     width: 50px;
     bottom: -50px; /* Default hidden position */
-    right: 1rem; /* Adjust as needed */
+    right: 1.5rem;
     opacity: 0;
     overflow: hidden;
     z-index: 1000;
     font-size: 21px;
     transition:
-        bottom 0.15s ease-out,
         opacity 0.15s ease-out;
 
     &.visible {
-        bottom: 1rem; /* Initial visible position */
+        bottom: 1.5rem; /* Initial visible position */
         opacity: 1;
     }
 }

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -51,25 +51,50 @@ $(document).ready(function () {
 /**
  * Back to top button
  */
+$(document).ready(function () {
+    var toggleHeight = $(window).outerHeight() / 2;
+    var targetDiv = $('#footer'); // Replace with the selector of your target div
+    function updateButtonPosition() {
+        var divHeight = targetDiv.outerHeight(); // Get the height of the target div
 
-var toggleHeight = $(window).outerHeight() / 2;
+        $(window).scroll(function () {
+            var scrollTop = $(window).scrollTop();
+            var windowHeight = $(window).height();
+            var documentHeight = $(document).height();
+            var remainingDistance = documentHeight - (scrollTop + windowHeight) + 25;
 
-$(window).scroll(function () {
-    if ($(window).scrollTop() > toggleHeight) {
-        //Adds active class to make button visible
-        $("#back-to-top").addClass("visible");
+            if (scrollTop > toggleHeight) {
+                $("#back-to-top").addClass("visible");
+            } else {
+                $("#back-to-top").removeClass("visible");
+            }
 
-    } else {
-        //Removes active class to make button visible
-        $("#back-to-top").removeClass("visible");
+            // Adjust the bottom position based on the height of the target div
+            if (remainingDistance < divHeight) {
+                $("#back-to-top").css('bottom', divHeight - remainingDistance + 'px');
+            } else {
+                $("#back-to-top").css('bottom', '1rem'); // Assuming you want to keep 1rem when not near the bottom
+            }
+        });
+    }
+
+    // Initial call to set the button position
+    updateButtonPosition();
+
+    // Update button position on window resize
+    $(window).resize(function () {
+        // Unbind the scroll event to avoid multiple bindings
+        $(window).off('scroll');
+        // Recalculate and rebind the scroll event with updated values
+        updateButtonPosition();
+    });
+    
+    // Scrolls the user to the top of the page again
+    window.topFunction = function () {
+        document.body.scrollTop = 0; // For Safari
+        document.documentElement.scrollTop = 0; // For Chrome, Firefox, IE and Opera
     }
 });
-
-//Scrolls the user to the top of the page again
-function topFunction() {
-    document.body.scrollTop = 0; // For Safari
-    document.documentElement.scrollTop = 0; // For Chrome, Firefox, IE and Opera
-}
 
 
 /**

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -53,27 +53,29 @@ $(document).ready(function () {
  */
 $(document).ready(function () {
     var toggleHeight = $(window).outerHeight() / 2;
-    var targetDiv = $('#footer'); // Replace with the selector of your target div
+    var targetDiv = $('#footer');
+    var $backToTop = $("#back-to-top");
+
     function updateButtonPosition() {
         var divHeight = targetDiv.outerHeight(); // Get the height of the target div
 
         $(window).scroll(function () {
             var scrollTop = $(window).scrollTop();
-            var windowHeight = $(window).height();
+            var windowHeight = $(window).height();  
             var documentHeight = $(document).height();
             var remainingDistance = documentHeight - (scrollTop + windowHeight) + 25;
 
             if (scrollTop > toggleHeight) {
-                $("#back-to-top").addClass("visible");
+                $backToTop.addClass("visible");
             } else {
-                $("#back-to-top").removeClass("visible");
+                $backToTop.removeClass("visible");
             }
 
             // Adjust the bottom position based on the height of the target div
             if (remainingDistance < divHeight) {
-                $("#back-to-top").css('bottom', divHeight - remainingDistance + 'px');
+                $backToTop.css('bottom', (divHeight - remainingDistance) + 'px');
             } else {
-                $("#back-to-top").css('bottom', '1rem'); // Assuming you want to keep 1rem when not near the bottom
+                $backToTop.css('bottom', '1.5rem');
             }
         });
     }
@@ -88,14 +90,13 @@ $(document).ready(function () {
         // Recalculate and rebind the scroll event with updated values
         updateButtonPosition();
     });
-    
+
     // Scrolls the user to the top of the page again
     window.topFunction = function () {
         document.body.scrollTop = 0; // For Safari
         document.documentElement.scrollTop = 0; // For Chrome, Firefox, IE and Opera
     }
 });
-
 
 /**
  * Making relevant events visible


### PR DESCRIPTION
This should let the the scroll to top button look better + make sure it does not go lower than the height of the footer, making sure the "Built by ETT" does not get covered (closes #260)

This should also work when:
- The window gets resized
- There is no footer present

Preview: https://bedroesb.github.io/elixir-toolkit-theme/