### PR TITLE
Improved scroll to top button + larger maximum break point

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -43,7 +43,7 @@
             {%- unless site.data.footer.copyright == nil %}
             <div class="d-flex align-items-center mb-3 mb-lg-0 mx-auto mx-lg-0 text-center">{{ site.data.footer.copyright | markdownify }}</div>
             {%- endunless %}
-            <div class="d-flex align-items-center mx-auto ms-lg-4 me-lg-0">
+            <div class="d-flex align-items-center mx-auto ms-lg-4 me-lg-45">
                 <a id="ett-logo" class="text-nowrap" href="https://elixir-belgium.github.io/elixir-toolkit-theme">Built with
                     <svg data-name="ETT logo" xmlns="http://www.w3.org/2000/svg" width="30" height="30" viewBox="0 0 77.2 77.12">
                         <defs>

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -43,8 +43,8 @@
             {%- unless site.data.footer.copyright == nil %}
             <div class="d-flex align-items-center mb-3 mb-lg-0 mx-auto mx-lg-0 text-center">{{ site.data.footer.copyright | markdownify }}</div>
             {%- endunless %}
-            <div class="d-flex align-items-center mx-auto ms-lg-4 me-lg-45">
-                <a id="ett-logo" class="text-nowrap" href="https://elixir-belgium.github.io/elixir-toolkit-theme">Built with
+            <div class="d-flex align-items-center mx-auto ms-lg-4 me-lg-0">
+                <a id="ett-logo" class="text-nowrap me-lg-5 me-xxxl-0" href="https://elixir-belgium.github.io/elixir-toolkit-theme">Built with
                     <svg data-name="ETT logo" xmlns="http://www.w3.org/2000/svg" width="30" height="30" viewBox="0 0 77.2 77.12">
                         <defs>
                             <style>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -20,7 +20,7 @@
         </div>
     </div>
     {%- if site.theme_variables.back_to_top or site.theme_variables.back_to_top == nil %}
-    <button id="back-to-top" class="btn btn-primary rounded-3" type="button" aria-hidden="true" onclick="topFunction()">
+    <button id="back-to-top" class="btn btn-primary btn-sm rounded-pill" type="button" aria-hidden="true" onclick="topFunction()">
         <i class="fa-solid fa-arrow-up"></i>
     </button>
     {%- endif %}

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -15,7 +15,10 @@ $h2-font-size: 1rem * 2.1 !default;
 $h1-font-size: 1rem * 3.3 !default;
 $card-border-width: 0;
 $custom-container-max-widths: (
-    xxxl: 1500px
+    xxxl: 1700px
+);
+$custom-spacers: (
+    45: 2.25rem
 );
 
 /*-----Initialize Bootstrap variables-----*/
@@ -25,6 +28,8 @@ $custom-container-max-widths: (
 
 /*-----Custom maps-----*/
 $container-max-widths: map-merge($container-max-widths, $custom-container-max-widths);
+$grid-breakpoints: map-merge($grid-breakpoints, $custom-container-max-widths);
+$spacers: map-merge($spacers, $custom-spacers);
 
 /*-----Include other SASS files-----*/
 @import "bootstrap/bootstrap";
@@ -895,11 +900,11 @@ li.past_event,
 // Main accordion style
 a.info-collapse {
     i {
-        transition: transform .2s ease-in-out;
+        transition: transform 0.2s ease-in-out;
         margin-right: $spacer;
     }
     h3 {
-        transition: color .2s ease-in-out;
+        transition: color 0.2s ease-in-out;
     }
     &[aria-expanded="true"] {
         i {
@@ -909,13 +914,13 @@ a.info-collapse {
     &:hover {
         i,
         h3 {
-            color: rgba($link-color, .8)!important;
+            color: rgba($link-color, 0.8) !important;
         }
     }
 }
 
 // Add a bottom border to the last accordion.
-a.info-collapse[aria-expanded="false"]:last-of-type, 
+a.info-collapse[aria-expanded="false"]:last-of-type,
 a.info-collapse[aria-expanded="true"]:last-of-type + .show {
     border-bottom: 1px solid $border-color;
 }

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -17,9 +17,6 @@ $card-border-width: 0;
 $custom-container-max-widths: (
     xxxl: 1700px
 );
-$custom-spacers: (
-    45: 2.25rem
-);
 
 /*-----Initialize Bootstrap variables-----*/
 
@@ -28,8 +25,6 @@ $custom-spacers: (
 
 /*-----Custom maps-----*/
 $container-max-widths: map-merge($container-max-widths, $custom-container-max-widths);
-$grid-breakpoints: map-merge($grid-breakpoints, $custom-container-max-widths);
-$spacers: map-merge($spacers, $custom-spacers);
 
 /*-----Include other SASS files-----*/
 @import "bootstrap/bootstrap";
@@ -600,6 +595,12 @@ footer {
 
     .copyright {
         background-color: $footer-copyright-bg;
+    }
+
+    @media (min-width: 1850px) {
+        .me-xxxl-0 {
+                margin-right: 0!important;
+            }
     }
 
     #ett-logo {

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -617,19 +617,20 @@ footer {
 
 #back-to-top {
     position: fixed;
-    bottom: -50px;
-    right: $spacer;
+    height: 50px;
+    width: 50px;
+    bottom: -50px; /* Default hidden position */
+    right: 1rem; /* Adjust as needed */
     opacity: 0;
     overflow: hidden;
     z-index: 1000;
     font-size: 21px;
-    padding: 12px 20px;
     transition:
         bottom 0.15s ease-out,
         opacity 0.15s ease-out;
 
     &.visible {
-        bottom: $spacer;
+        bottom: 1rem; /* Initial visible position */
         opacity: 1;
     }
 }

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -51,50 +51,26 @@ $(document).ready(function () {
 /**
  * Back to top button
  */
-$(document).ready(function () {
-    var toggleHeight = $(window).outerHeight() / 2;
-    var targetDiv = $('#footer'); // Replace with the selector of your target div
-    function updateButtonPosition() {
-        var divHeight = targetDiv.outerHeight(); // Get the height of the target div
 
-        $(window).scroll(function () {
-            var scrollTop = $(window).scrollTop();
-            var windowHeight = $(window).height();
-            var documentHeight = $(document).height();
-            var remainingDistance = documentHeight - (scrollTop + windowHeight) + 25;
+var toggleHeight = $(window).outerHeight() / 2;
 
-            if (scrollTop > toggleHeight) {
-                $("#back-to-top").addClass("visible");
-            } else {
-                $("#back-to-top").removeClass("visible");
-            }
+$(window).scroll(function () {
+    if ($(window).scrollTop() > toggleHeight) {
+        //Adds active class to make button visible
+        $("#back-to-top").addClass("visible");
 
-            // Adjust the bottom position based on the height of the target div
-            if (remainingDistance < divHeight) {
-                $("#back-to-top").css('bottom', divHeight - remainingDistance + 'px');
-            } else {
-                $("#back-to-top").css('bottom', '1rem'); // Assuming you want to keep 1rem when not near the bottom
-            }
-        });
-    }
-
-    // Initial call to set the button position
-    updateButtonPosition();
-
-    // Update button position on window resize
-    $(window).resize(function () {
-        // Unbind the scroll event to avoid multiple bindings
-        $(window).off('scroll');
-        // Recalculate and rebind the scroll event with updated values
-        updateButtonPosition();
-    });
-    
-    // Scrolls the user to the top of the page again
-    window.topFunction = function () {
-        document.body.scrollTop = 0; // For Safari
-        document.documentElement.scrollTop = 0; // For Chrome, Firefox, IE and Opera
+    } else {
+        //Removes active class to make button visible
+        $("#back-to-top").removeClass("visible");
     }
 });
+
+//Scrolls the user to the top of the page again
+function topFunction() {
+    document.body.scrollTop = 0; // For Safari
+    document.documentElement.scrollTop = 0; // For Chrome, Firefox, IE and Opera
+}
+
 
 
 /**

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -51,25 +51,50 @@ $(document).ready(function () {
 /**
  * Back to top button
  */
+$(document).ready(function () {
+    var toggleHeight = $(window).outerHeight() / 2;
+    var targetDiv = $('#footer'); // Replace with the selector of your target div
+    function updateButtonPosition() {
+        var divHeight = targetDiv.outerHeight(); // Get the height of the target div
 
-var toggleHeight = $(window).outerHeight() / 2;
+        $(window).scroll(function () {
+            var scrollTop = $(window).scrollTop();
+            var windowHeight = $(window).height();
+            var documentHeight = $(document).height();
+            var remainingDistance = documentHeight - (scrollTop + windowHeight) + 25;
 
-$(window).scroll(function () {
-    if ($(window).scrollTop() > toggleHeight) {
-        //Adds active class to make button visible
-        $("#back-to-top").addClass("visible");
+            if (scrollTop > toggleHeight) {
+                $("#back-to-top").addClass("visible");
+            } else {
+                $("#back-to-top").removeClass("visible");
+            }
 
-    } else {
-        //Removes active class to make button visible
-        $("#back-to-top").removeClass("visible");
+            // Adjust the bottom position based on the height of the target div
+            if (remainingDistance < divHeight) {
+                $("#back-to-top").css('bottom', divHeight - remainingDistance + 'px');
+            } else {
+                $("#back-to-top").css('bottom', '1rem'); // Assuming you want to keep 1rem when not near the bottom
+            }
+        });
+    }
+
+    // Initial call to set the button position
+    updateButtonPosition();
+
+    // Update button position on window resize
+    $(window).resize(function () {
+        // Unbind the scroll event to avoid multiple bindings
+        $(window).off('scroll');
+        // Recalculate and rebind the scroll event with updated values
+        updateButtonPosition();
+    });
+    
+    // Scrolls the user to the top of the page again
+    window.topFunction = function () {
+        document.body.scrollTop = 0; // For Safari
+        document.documentElement.scrollTop = 0; // For Chrome, Firefox, IE and Opera
     }
 });
-
-//Scrolls the user to the top of the page again
-function topFunction() {
-    document.body.scrollTop = 0; // For Safari
-    document.documentElement.scrollTop = 0; // For Chrome, Firefox, IE and Opera
-}
 
 
 /**


### PR DESCRIPTION
Because the previous attempt #263 did not play nicely on mobile, I am trying here a different approach based on the suggestions by @elichad.

This pull request will make the scroll to top round, smaller, and the "Built by ETT" will have a margin in non mobile mode, preventing it to be overlapped by the Scroll to top button.

Preview it here: https://bedroesb.github.io/elixir-toolkit-theme