### PR TITLE
Better handling of national resources

### DIFF
--- a/_includes/resource-table-all.html
+++ b/_includes/resource-table-all.html
@@ -4,7 +4,21 @@
 {%- assign tools = site.data.tool_and_resource_list | add_related_pages | sort_natural: "name" %}
 {%- endif %}
 {%- assign country_pages = site.pages | where_exp: "item", "item.search_exclude != true" | where_exp:"item","item.national_resources != nil" %}
-{%- unless tools.size == 0 or tools == nil %}
+{%- unless country_pages.size == 0  %}
+{%- assign tool_matches_total = 0 %}
+{%- assign query = "related_pages." | append: page.type %}
+{%- for country_page in country_pages %}
+{%- if include.tag %}
+{%- assign tool_matches = country_page.national_resources | where_exp:"resource","resource.related_pages != nil" | where: query, include.tag %}
+{%- unless tool_matches.size == 0  %}
+{%- assign tool_matches_total = tool_matches_total | plus: tool_matches.size %}
+{%- endunless %}
+{%- else %}
+{%- assign tool_matches_total = tool_matches_total | plus: country_page.national_resources.size %}
+{%- endif %}
+{%- endfor %}
+{%- endunless %}
+{%- unless tools.size == 0  and tool_matches_total.size == 0 %}
 {%- if include.tag %}
 <a class="visually-hidden-focusable" href='#skip-tool-table'>Skip tool table</a>
 {%- if site.theme_variables.headings.resource-table-all-collapse %}
@@ -17,6 +31,7 @@
 <div class="collapse info-card" id="tools_collapse">
 {%- endif %}
 {%- endif %}
+{%- unless tools.size == 0 %}
 <div class="table-responsive mt-4">
     <table class="tooltable table display">
         <thead>
@@ -36,14 +51,9 @@
             {%- for tool in tools %}
             <tr>
                 {%- assign instances_tool = 0 %}
-                {%- assign total_county_tools = 0 %}
                 {%- assign query = "related_pages." | append: page.type %}
                 {%- for country_page in country_pages %}
                 {%- assign instance_matches = country_page.national_resources | where: "instance_of", tool.id | where_exp:"resource","resource.related_pages != nil" | where: query, include.tag %}
-                {%- assign tool_matches = country_page.national_resources | where_exp:"resource","resource.related_pages != nil" | where: query, include.tag %}
-                {%- unless tool_matches.size == 0 %}
-                {%- assign total_county_tools = total_county_tools | plus: tool_matches.size %}
-                {%- endunless %}
                 {%- unless instance_matches.size == 0 %}
                 {%- assign instances_tool = instances_tool | plus: instance_matches.size %}
                 {%- endunless %}
@@ -54,7 +64,7 @@
                 <td>{{tool.name}}</td>
                 {%- endif %}
                 <td>{{tool.description}}
-                    {%- if tool.instance_of or tool.how_to_access or instances_tool != 0 and total_county_tools != 0 and include.tag != nil %}
+                    {%- if tool.instance_of or tool.how_to_access or instances_tool != 0 != 0 and include.tag != nil %}
                     {%- assign linked_tool = site.data.tool_and_resource_list | where:"id", tool.instance_of | first %}
                     <div class="d-block mt-1">
                         {%- if linked_tool %}
@@ -63,7 +73,7 @@
                         {%- if tool.how_to_access %}
                         <span class="d-inline-block" tabindex="0" data-bs-toggle="tooltip" title="{{tool.how_to_access}}"><span class="badge text-primary border border-primary"> <i class="fa-solid fa-key"></i></span></span>
                         {%- endif %}
-                        {%- unless instances_tool == 0 or total_county_tools == 0 or include.tag == nil %}
+                        {%- unless instances_tool == 0 or include.tag == nil %}
                         <!-- <a href="#national-resources-button">
                         <span class="badge text-white bg-primary"><i class="fa-solid fa-arrow-circle-down me-2"></i>Different instances available</span>
                     </a> -->
@@ -99,16 +109,20 @@
                 </td>
             </tr>
             {%- endfor %}
+{%- if tool_matches_total == 0 or include.tag %}
         </tbody>
     </table>
 </div>
+{%- endif %}
 {%- if include.tag %}
 {%- if site.theme_variables.headings.resource-table-all-collapse %}
 </div>
 {%- endif %}
 <div id="skip-tool-table"></div>
 {%- endif %}
-{%- unless total_county_tools == 0 or include.tag == nil %}
+
+{%- endunless %}
+{%- unless tool_matches_total == 0 %}
 {%- if include.tag %}
 <a class="visually-hidden-focusable" href='#skip-nat-tool-table'>Skip national tools table</a>
 {%- if site.theme_variables.headings.resource-table-all-collapse %}
@@ -120,37 +134,34 @@
 </a>
 <div class="collapse info-card" id="nat_tools_collapse">
 {%- endif %}
-{%- endif %}
 <p class="mt-4">Tools and resources tailored to users in different countries.</p>
 <div class="table-responsive mt-3">
-    <table class="tooltable table display" id="national-resources-button">
+    <table class="tooltable table display">
         <thead>
             <tr class="text-nowrap">
-                <th>Tool or resource {%- if include.tag -%}
+                <th>Tool or resource
                     <a data-bs-toggle="tooltip" data-bs-original-title="This is a curated list which means that not all tools or resources that exist for this topic are listed here. This is mainly because we do not intend to be a registry. In most cases you will only find back the tools or resources that are mentioned in this page.">
                         <i class="fa-solid fa-info-circle"></i>
-                    </a>{%- endif %}
+                    </a>
                 </th>
                 <th>Description</th>
                 <th>Related pages</th>
-                <th>Registry {%- if include.tag -%}
+                <th>Registry
                     <a data-bs-toggle="tooltip" data-bs-original-title="Links to related information in ELIXIR registries: related policies and standards in FAIRsharing, scientific and technical descriptions of the resource in bio.tools, and related training in TeSS.">
                         <i class="fa-solid fa-info-circle"></i>
-                    </a>{%- endif %}
+                    </a>
                 </th>
             </tr>
         </thead>
         <tbody>
-            {%- assign hide_ids = "resource_title" %}
+{%- endif %}
             {%- for country_page in country_pages %}
             {%- if include.tag %}
-            {%- assign tool_matches = country_page.national_resources | where_exp:"resource","resource.related_pages != nil" | where: query, include.tag | sort_natural: "name" %}
+            {%- assign tool_matches = country_page.national_resources | where_exp:"resource","resource.related_pages != nil" | where: query, include.tag %}
             {%- else %}
-            {%- assign tool_matches = country_page.national_resources | sort_natural: "name" %}
+            {%- assign tool_matches = country_page.national_resources %}
             {%- endif %}
             {%- for tool in tool_matches %}
-            {%- assign tool_id = tool.name | slugify %}
-            {%- assign hide_ids = hide_ids | append: " " | append: tool_id %}
             <tr>
                 {% if tool.url %}
                 <td><a href="{{tool.url}}">{{tool.name}}</a><a href="{{country_page.url | relative_url }}" data-bs-toggle="tooltip" title="{{country_page.title}}"><span class="flag-icon ms-2 shadow-sm flag-icon-{{country_page.country_code | downcase }}"></span></a></td>

--- a/_includes/resource-table-all.html
+++ b/_includes/resource-table-all.html
@@ -157,7 +157,7 @@
 {%- endif %}
             {%- for country_page in country_pages %}
             {%- if include.tag %}
-            {%- assign tool_matches = country_page.national_resources | where_exp:"resource","resource.related_pages != nil" | where: query, include.tag %}
+            {%- assign tool_matches = country_page.national_resources | where_exp:"resource","resource.related_pages != nil" | where: query, include.tag | sort_natural: "name" %}
             {%- else %}
             {%- assign tool_matches = country_page.national_resources %}
             {%- endif %}


### PR DESCRIPTION
This will fix #238 by listing the national resources when not tag is present.

It will also add support for pages to have only national resources, and it is not a national page itself.