### PR TITLE
[Hotfix] Tools and resources section gets rendered only when tools are available.

### DIFF
--- a/_data/sidebars/main.yml
+++ b/_data/sidebars/main.yml
@@ -51,6 +51,8 @@ subitems:
             url: /general_page_3
           - title: General page 4
             url: /general_page_4
+          - title: General page 5
+            url: /general_page_5
       - title: All trainings
         url: /all_trainings
       - title: Website overview

--- a/_includes/more-information-tiles.html
+++ b/_includes/more-information-tiles.html
@@ -38,15 +38,25 @@
 {%- endif %}
 {%- endfor %}
 {%- endif %}
-{%- if page.page_id %}
+{%- if page.page_id and site.theme_variables.headings.resource-table-all-collapse%}
 {%- assign tools = site.data.tool_and_resource_list | where:"related_pages", page.page_id %}
-{%- unless tools.size == 0 or tools == nil %}
-{%- if site.theme_variables.headings.resource-table-all-collapse %}
+{%- unless tools.size == 0 %}
 {%- assign actual_tools = 1 %}
-{%- endif %}
+{%- endunless %}
+{%- assign country_pages = site.pages | where_exp: "item", "item.search_exclude != true" | where_exp:"item","item.national_resources != nil" %}
+{%- unless country_pages.size == 0 %}
+{%- assign tool_matches_total = 0 %}
+{%- assign query = "related_pages." | append: page.type %}
+{%- for country_page in country_pages %}
+{%- assign tool_matches = country_page.national_resources | where_exp:"resource","resource.related_pages != nil" | where: query, page.page_id %}
+{%- assign tool_matches_total = tool_matches_total | plus: tool_matches.size %}
+{%- endfor %}
+{%- endunless %}
+{%- unless tool_matches_total == 0 %}
+{%- assign actual_nat_tools = 1 %}
 {%- endunless %}
 {%- endif %}
-{%- if actual_fairsharing or actual_faircookbook or actual_dsw or actual_rdmkit or actual_dsw or actual_training or actual_tools %}
+{%- if actual_fairsharing or actual_faircookbook or actual_dsw or actual_rdmkit or actual_dsw or actual_training or actual_tools or actual_nat_tools %}
 <h2 class="mb-4">{{site.theme_variables.headings.more-information-tiles | default: 'More information' }}</h2>
 {%- endif %}
 

--- a/_includes/resource-table-all.html
+++ b/_includes/resource-table-all.html
@@ -19,7 +19,7 @@
 {%- endfor %}
 {%- endunless %}
 {%- unless tools.size == 0  and tool_matches_total == 0 %}
-{%- if include.tag %}
+{%- if include.tag and tools.size != 0 %}
 <a class="visually-hidden-focusable" href='#skip-tool-table'>Skip tool table</a>
 {%- if site.theme_variables.headings.resource-table-all-collapse %}
 <a data-bs-toggle="collapse" href="#tools_collapse" role="button" aria-expanded="false" aria-controls="tools_collapse" class="d-flex align-items-baseline pb-3 border-top info-collapse">
@@ -30,6 +30,8 @@
 </a>
 <div class="collapse info-card" id="tools_collapse">
 {%- endif %}
+{%- elsif tools.size == 0 and site.theme_variables.headings.resource-table-all-collapse == false or site.theme_variables.headings.resource-table-all-collapse == nil %}
+<h2 class="h2-like fs-2">{{site.theme_variables.headings.resource-table-all | default: 'Tools and resources on this page' }}</h2>
 {%- endif %}
 {%- unless tools.size == 0 %}
 <div class="table-responsive mt-4">

--- a/_includes/resource-table-all.html
+++ b/_includes/resource-table-all.html
@@ -18,7 +18,7 @@
 {%- endif %}
 {%- endfor %}
 {%- endunless %}
-{%- unless tools.size == 0  and tool_matches_total.size == 0 %}
+{%- unless tools.size == 0  and tool_matches_total == 0 %}
 {%- if include.tag %}
 <a class="visually-hidden-focusable" href='#skip-tool-table'>Skip tool table</a>
 {%- if site.theme_variables.headings.resource-table-all-collapse %}

--- a/elixir-toolkit-theme.gemspec
+++ b/elixir-toolkit-theme.gemspec
@@ -3,7 +3,7 @@
 Gem::Specification.new do |spec|
   spec.name          = "elixir-toolkit-theme"
 
-  spec.version       = "3.1.0"
+  spec.version       = "3.1.1"
   spec.authors       = ["bedroesb"]
   spec.email         = ["bedro@psb.vib-ugent.be\n"]
 

--- a/pages/example_pages/general_page_3.md
+++ b/pages/example_pages/general_page_3.md
@@ -15,7 +15,7 @@ national_resources:
     how_to_access: explantation on how you can access this resource
     instance_of: github
     related_pages:
-      example_pages: [gp3, gp1, gp2]
+      example_pages: [gp5, gp2]
     registry:
       biotools: bioconda
       tess: Bioconda
@@ -24,7 +24,7 @@ national_resources:
     how_to_access: 
     instance_of: 
     related_pages:
-      example_pages: [gp3]
+      example_pages: [gp5]
   - name: Resource name 3
     description: A general description about the resource
     how_to_access: 

--- a/pages/example_pages/general_page_5.md
+++ b/pages/example_pages/general_page_5.md
@@ -1,0 +1,22 @@
+---
+title: General page example 5
+type: example_pages
+contributors: [Bert Droesbeke, Long Example Contributor , Example Contributor, Example Contributor, Example Contributor, Example Contributor, Example Contributor, Example Contributor, Example Contributor]
+coordinators: [Bert Droesbeke] 
+description: This description is used when the page is listed
+page_id: gp5
+related_pages: 
+    example_pages: [gp2, gp3]
+---
+
+
+Lorem dolor sit amet, consectetur adipiscing elit. Etiam quis fermentum velit, at vulputate sapien. Suspendisse efficitur id elit sed volutpat. Etiam luctus sem id finibus pulvinar. Morbi sit amet purus a velit pretium imperdiet ut et elit. Maecenas eleifend, urna a aliquam lobortis, erat ligula efficitur velit, aliquam accumsan odio turpis nec nibh. Suspendisse placerat porttitor neque, vitae consequat massa aliquam eu. Aliquam erat volutpat. Class aptent taciti sociosqu ad litora torquent per conubia nostra, per inceptos himenaeos. Proin sed velit vitae tellus egestas condimentum. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia curae; Mauris pretium scelerisque dignissim. Maecenas ipsum nisl, pretium non mollis ac, varius pulvinar nibh. Donec venenatis pulvinar arcu, vitae interdum purus dictum in. Proin sed tempus mi.
+
+## Lorem Ipsum
+
+Nam non sollicitudin sapien. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia curae; Maecenas consectetur nulla nec rutrum rhoncus. Sed non urna sem. Maecenas sed lobortis urna, hendrerit aliquet massa. Phasellus felis dui, feugiat ut sapien vel, mattis dictum eros. Suspendisse in felis sit amet dui elementum rutrum tristique eget velit. Sed hendrerit, ante sit amet hendrerit cursus, ante nibh accumsan nibh, vitae rhoncus quam ipsum placerat ante.
+
+### Lorem Ipsum
+
+Suspendisse potenti. Aliquam molestie tortor ac semper imperdiet. Sed nec laoreet odio. Aliquam erat volutpat. Aenean odio velit, tristique et mauris ac, porta lacinia ipsum. Vivamus massa quam, egestas in dui eget, porta pharetra tellus. Aliquam blandit ante eu ligula molestie pellentesque. Morbi non diam at leo euismod sagittis quis in magna. Ut vitae ligula sit amet nulla rhoncus ultrices vitae quis odio. Nam euismod nunc interdum tellus pulvinar, et interdum magna gravida.
+


### PR DESCRIPTION
This is one that slipped through the cracks. I also create here a new test scenario: A page with national tools, that is not a national page, and has no normal tools. 

This works both with more information collapsed or non collapsed.