### PR TITLE
Create new include scroll-top.html for the scroll to top button

### DIFF
--- a/_includes/scroll-top.html
+++ b/_includes/scroll-top.html
@@ -1,0 +1,5 @@
+{%- if site.theme_variables.back_to_top or site.theme_variables.back_to_top == nil %}
+<button id="back-to-top" class="btn btn-primary btn-sm rounded-pill" type="button" aria-hidden="true" onclick="topFunction()">
+    <i class="fa-solid fa-arrow-up"></i>
+</button>
+{%- endif %}

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -19,11 +19,7 @@
             {{content}}
         </div>
     </div>
-    {%- if site.theme_variables.back_to_top or site.theme_variables.back_to_top == nil %}
-    <button id="back-to-top" class="btn btn-primary btn-sm rounded-pill" type="button" aria-hidden="true" onclick="topFunction()">
-        <i class="fa-solid fa-arrow-up"></i>
-    </button>
-    {%- endif %}
+    {% include scroll-top.html %}
     {% include footer.html %}
     {% include cookie-popup.html %}
 </body>


### PR DESCRIPTION
Adding it to its own include makes that it can be easily reused throughout layouts, this also means that when the design/html of the button changes, this is applied everywhere.