### PR TITLE
FEAT: Make the development info banner optional

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -59,6 +59,7 @@ plugins:
 theme_variables: 
   # git_host: GitHub
   # back_to_top: true
+  # dev-info-banner: false
   # privacy_statement_url: /privacy
   # github_buttons: 
   #   position: top

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -3,7 +3,7 @@
 {% include head.html %}
 <body class="d-flex flex-column min-vh-100"{% unless page.toc == false %} data-bs-spy="scroll" data-bs-target="#toc-contents" data-bs-smooth-scroll="true" tabindex="0"{% endunless %}>
     {% if site.topnav_banner %}{% include banner.html %}{% endif %}
-    {% if jekyll.environment == "development" %}{% include dev-info.html %}{% endif %}
+    {% if jekyll.environment == "development" and site.theme_variables.dev-info-banner == true %}{% include dev-info.html %}{% endif %}
     {% include topnav.html %}
     <!-- Page Content -->
     <div class="container flex-grow-1">

--- a/elixir-toolkit-theme.gemspec
+++ b/elixir-toolkit-theme.gemspec
@@ -3,7 +3,7 @@
 Gem::Specification.new do |spec|
   spec.name          = "elixir-toolkit-theme"
 
-  spec.version       = "3.1.1"
+  spec.version       = "3.2.0"
   spec.authors       = ["bedroesb"]
   spec.email         = ["bedro@psb.vib-ugent.be\n"]
 

--- a/pages/documentation/configuring_theme.md
+++ b/pages/documentation/configuring_theme.md
@@ -74,29 +74,29 @@ theme_variables:
 
 More detailed information about these settings can be found here:
 
-* `git_host`: This can be **Github** or **GitLab** and customizes the text in the top navigation.
+* `git_host`: This can be *Github* or *GitLab* and customizes the text in the top navigation.
 * `back_to_top`: Enables the appearance of the back to top button
 * `dev-info-banner`: Show a development banner including the commit and branch the website is deployed from, when the [Jekyll environment](https://jekyllrb.com/docs/configuration/environments/) is "development". Default: *false*
 * `privacy_statement_url`: Custom path to the privacy page that contains the privacy statement. This is used to link towards in the cookie banner.
-* github_buttons: Buttons that link towards github related.
-  * `position`: Can be either **top**, next to the title or **bottom**, under the page content.
+* **github_buttons**: Buttons that link towards github related.
+  * `position`: Can be either *top*, next to the title or *bottom*, under the page content.
   * `edit_me`: Enable the 'propose an edit on this page' button.
   * `open_issue`: Enable the 'open an issue on this page' button.
   * `history`: Enable the 'history of this page' button.
-* headings: Change the subtitles or collapse the page sections that are automatically generated
+* **headings**: Change the subtitles or collapse the page sections that are automatically generated
     `related-pages`: Default: Related pages
     `more-information-tiles`:  Default: More information
     `resource-table-all`: Default: Tools and resources on this page
     `resource-table-all-collapse`: Make the tools and resources table collapsed like the other more information sections. This will also make the tools and resources table and National resources part of the More information heading. Default: *False*
     `affiliation-tiles-page`: Default: Affiliations
     `contributor-minitiles-page`: Default: Contributors
-* toc: Settings related to the table of contents.
+* **toc**: Settings related to the table of contents.
   * `min_headings`: The minimum amount of headings (h2, h3,.. depending on the headings option) on a page for the toc to appear. This has to be an integer. Default: *1*
-  * `headings`: The type of headings that need to be indexed by the toc. This can be a list or one value, ex: **'h1, h2, h3'** or **'h2'**. Default: *main h2*
-* topnav: Settings related to the top navigation.
-  *  `theme`: This variable is needed to change between a dark and a light top navigation. possible values: **dark** and **light**
+  * `headings`: The type of headings that need to be indexed by the toc. This can be a list or one value, ex: *'h1, h2, h3'* or *'h2'*. Default: *'main h2'*
+* **topnav**: Settings related to the top navigation.
+  *  `theme`: This variable is needed to change between a dark and a light top navigation. possible values: *dark* and *light*
   *  `brand_logo`: Custom path towards the brand logo, in case the assets/img/main_logo.svg can not be used.
-  *  `github`: Enable or disable the appearance of the Github repo nav link
-  *  `twitter`: Enable or disable the appearance of the Twitter nav link by adding the url towards the twitter page. Disabling is done by giving de value **false** as seen in the example.
+  *  `github`: Enable or disable the appearance of the Github repo nav link. Default: *true*
+  *  `twitter`: Enable or disable the appearance of the Twitter nav link by adding the url towards the twitter page. Default: *false*
 * `theme_color`: This is the primary theme color which is used in the metadata of the website. Please use the hex color without the hashtag as value.
 * `fonts`: List here the urls towards google fonts to include custom fonts for your website.

--- a/pages/documentation/configuring_theme.md
+++ b/pages/documentation/configuring_theme.md
@@ -45,6 +45,7 @@ Certain features are not always needed and can be disabled are changed in your d
 theme_variables: 
   git_host: GitHub
   back_to_top: true
+  dev-info-banner: false
   privacy_statement_url: /privacy
   github_buttons: 
     position: top
@@ -74,7 +75,8 @@ theme_variables:
 More detailed information about these settings can be found here:
 
 * `git_host`: This can be **Github** or **GitLab** and customizes the text in the top navigation.
-* `back_to_top`: Enables the appearance of the back to top button 
+* `back_to_top`: Enables the appearance of the back to top button
+* `dev-info-banner`: Show a development banner including the commit and branch the website is deployed from, when the [Jekyll environment](https://jekyllrb.com/docs/configuration/environments/) is "development". Default: *false*
 * `privacy_statement_url`: Custom path to the privacy page that contains the privacy statement. This is used to link towards in the cookie banner.
 * github_buttons: Buttons that link towards github related.
   * `position`: Can be either **top**, next to the title or **bottom**, under the page content.


### PR DESCRIPTION
New configuration option:

```yml
theme_variables: 
  dev-info-banner: false
```

* `dev-info-banner`: Show a development banner including the commit and branch the website is deployed from, when the [Jekyll environment](https://jekyllrb.com/docs/configuration/environments/) is "development". Default: *false*


This will close #258 