### PR TITLE
Homogenize spacing between section navigation tiles

### DIFF
--- a/_includes/section-navigation-tiles-simple.html
+++ b/_includes/section-navigation-tiles-simple.html
@@ -1,6 +1,6 @@
 {%- assign allcountries = site.data.countries %}
 {%- assign except = include.except | split: ", " %}
-<div class="row row-cols-1 row-cols-md-2 row-cols-lg-{{ include.col | default: 2 }} gy-2 gx-4 my-4 navigation-tiles">
+<div class="row row-cols-1 row-cols-md-2 row-cols-lg-{{ include.col | default: 2 }} gy-4 navigation-tiles">
     {%- for current_page in site.pages | sorted %}
     {%- if current_page.title and current_page.search_exclude != true and current_page.type == include.type %}
     {%- unless except contains current_page.name %}


### PR DESCRIPTION
Currently the simple section navigation tiles had less y-spacing than the other navigation tiles (related pages + section navigation tiles) This should be the same now. Closes #239 