### PR TITLE
Make the topnav search placeholder more universal

### DIFF
--- a/_includes/section-navigation-tiles.html
+++ b/_includes/section-navigation-tiles.html
@@ -137,6 +137,7 @@
 </div>
 
 
+{%- if include.affiliations == true or include.search == true %}
 <script type="text/javascript">
     /** 
      * Filter cards by affiliation
@@ -218,3 +219,4 @@
     });
 
 </script>
+{%- endif %}

--- a/_includes/section-navigation-tiles.html
+++ b/_includes/section-navigation-tiles.html
@@ -36,8 +36,8 @@
     {%- if include.search == true %}
     <div class="col">
         <div class="input-group">
-            <span class="input-group-text" id="search-label">Search</span>
-            <input type="text" id="title-search" class="form-control" onkeyup="StartSearch();" placeholder="Type here..." aria-label="{{page.type | replace: '_', ' ' |}}" aria-describedby="search-label">
+            <span class="input-group-text" id="search-label-tiles"><i class="fa-solid fa-magnifying-glass"></i></span>
+            <input type="text" id="title-search" class="form-control" onkeyup="StartSearch();" placeholder="Find your page..." aria-label="{{page.type | replace: '_', ' ' |}}" aria-describedby="search-label-tiles">
             <button class="btn btn-primary" title="Button to clear search" type="button" id="clearsearch">
                 <i class="fa-solid fa-backspace"></i>
             </button>

--- a/_includes/topnav.html
+++ b/_includes/topnav.html
@@ -74,7 +74,7 @@
                     <li class="nav-item">
                         <div class="position-relative">
                             <form role="search" class="input-group">
-                                <span class="input-group-text" id="search-label"><i class="fa-solid fa-magnifying-glass"></i></span><input type="search" id="search-input" class="search-input form-control" tabindex="0" placeholder="Search {{ site.title }}" aria-label="Search {{ site.title }}" autocomplete="off">
+                                <span class="input-group-text" id="search-label"><i class="fa-solid fa-magnifying-glass"></i></span><input type="search" id="search-input" class="search-input form-control" tabindex="0" placeholder="Search" aria-label="Search" autocomplete="off">
                             </form>
                             <div id="search-results" class="search-results"></div>
                         </div>

--- a/_includes/topnav.html
+++ b/_includes/topnav.html
@@ -74,7 +74,7 @@
                     <li class="nav-item">
                         <div class="position-relative">
                             <form role="search" class="input-group">
-                                <span class="input-group-text" id="search-label"><i class="fa-solid fa-magnifying-glass"></i></span><input type="search" id="search-input" class="search-input form-control" tabindex="0" placeholder="Search" aria-label="Search" autocomplete="off">
+                                <span class="input-group-text" id="search-label"><i class="fa-solid fa-magnifying-glass"></i></span><input type="search" id="search-input" class="search-input form-control" tabindex="0" placeholder="Search..." aria-label="Search..." autocomplete="off">
                             </form>
                             <div id="search-results" class="search-results"></div>
                         </div>


### PR DESCRIPTION
Since it is difficult to find "one size fits all". I think it is better to strip the title away from the Search placeholder. 

Where it goes well:

![image](https://github.com/user-attachments/assets/c3bb2d5f-105d-4f6e-aa7a-498c549b053c)

Where it goes wrong:

![image](https://github.com/user-attachments/assets/03fd243b-4ca4-48c2-88d4-a9d79155e8b9)

New proposal:

![image](https://github.com/user-attachments/assets/fc30ddc1-05ae-40b8-b388-8f034c37c3b1)

