### PR TITLE
Update twitter icon to X

### DIFF
--- a/_includes/topnav.html
+++ b/_includes/topnav.html
@@ -53,7 +53,7 @@
                     {%- endif %}
                     {%- if site.theme_variables.topnav.twitter %}
                     <li class="nav-item">
-                        <a class="nav-link ps-2 d-flex align-items-center" href="{{site.theme_variables.topnav.twitter}}"><i class="fa-brands fa-twitter me-2"></i>Twitter</a>
+                        <a class="nav-link ps-2 d-flex align-items-center" href="{{site.theme_variables.topnav.twitter}}"><i class="fa-brands fa-x-twitter me-2"></i>Twitter</a>
                     </li>
                     {%- endif %}
                     {%- if site.theme_variables.topnav.github or site.theme_variables.topnav.github == nil %}


### PR DESCRIPTION
Because X as icon, with X as text, looks off, I decided to keep the twitter text for now. 

![image](https://github.com/user-attachments/assets/7e8149e5-66f6-4306-a705-353d84093959)

This will close #303 