### PR TITLE
Add support for contributor affiliation as both a list and a string

### DIFF
--- a/_data/CONTRIBUTORS.yml
+++ b/_data/CONTRIBUTORS.yml
@@ -7,7 +7,7 @@
 #    email: email adress
 #    orcid: orcid id
 #    role: the role of the contributor
-#    affiliation: affiliation
+#    affiliation: affiliation or ["affiliation 1", "affiliation 2"]
 #    image_url: absolute path to image (default image from github)
 
 # Bert Droesbeke:
@@ -15,7 +15,7 @@
 #     email: bert.droesbeke@vib.be
 #     orcid: 0000-0003-0522-5674
 #     role: editor
-#     affiliation: VIB Data Core / ELIXIR-BE
+#     affiliation: ["VIB Data Core", "ELIXIR-BE"]
 # Short example contributor:
 #     affiliation: Affiliation 
 # Long example contributor:

--- a/_includes/contributor-carousel-selection.html
+++ b/_includes/contributor-carousel-selection.html
@@ -17,7 +17,7 @@
 {%- else %}
 {%- for page in site.pages %}
 {%- if page.contributors and page.search_exclude != true and page.contributors.size != 0 %}
-{%- assign pagecontr = page.contributors | join: ", " %}
+{%- assign pagecontr = page.contributors | join: " / " %}
 {%- if allcontrstr %}
 {%- assign allcontrstr = allcontrstr | append: ", " | append: pagecontr %}
 {%- else %}

--- a/_includes/contributor-carousel-selection.html
+++ b/_includes/contributor-carousel-selection.html
@@ -87,7 +87,7 @@
                     <div class="card-body text-center py-0">
                         <p class="card-title">{{ contributor }}</p>
                         {%- if contributors[contributor].affiliation %}
-                        <p class="card-affiliation">{{ contributors[contributor].affiliation }}</p>
+                        <p class="card-affiliation">{{ contributors[contributor].affiliation | join: ", " }}</p>
                         {%- endif %}
                     </div>
                     {%- if contributors[contributor].git or contributors[contributor].email or contributors[contributor].orcid %}

--- a/_includes/contributor-carousel-selection.html
+++ b/_includes/contributor-carousel-selection.html
@@ -17,7 +17,7 @@
 {%- else %}
 {%- for page in site.pages %}
 {%- if page.contributors and page.search_exclude != true and page.contributors.size != 0 %}
-{%- assign pagecontr = page.contributors | join: " / " %}
+{%- assign pagecontr = page.contributors | join: ", " %}
 {%- if allcontrstr %}
 {%- assign allcontrstr = allcontrstr | append: ", " | append: pagecontr %}
 {%- else %}
@@ -87,7 +87,7 @@
                     <div class="card-body text-center py-0">
                         <p class="card-title">{{ contributor }}</p>
                         {%- if contributors[contributor].affiliation %}
-                        <p class="card-affiliation">{{ contributors[contributor].affiliation | join: ", " }}</p>
+                        <p class="card-affiliation">{{ contributors[contributor].affiliation | join: " / " }}</p>
                         {%- endif %}
                     </div>
                     {%- if contributors[contributor].git or contributors[contributor].email or contributors[contributor].orcid %}

--- a/_includes/contributor-minitiles-page.html
+++ b/_includes/contributor-minitiles-page.html
@@ -87,7 +87,7 @@
               <div class="card-body text-center py-0">
                 <p class="card-title">{{ stripped_name }}</p>
                 {%- if contributors[contributor].affiliation %}
-                <p class="card-affiliation">{{ contributors[contributor].affiliation }}</p>
+                <p class="card-affiliation">{{ contributors[contributor].affiliation | join: ", " }}</p>
                 {%- endif %}
               </div>
               {%- if contributors[contributor].git or contributors[contributor].email or contributors[contributor].orcid %}

--- a/_includes/contributor-minitiles-page.html
+++ b/_includes/contributor-minitiles-page.html
@@ -87,7 +87,7 @@
               <div class="card-body text-center py-0">
                 <p class="card-title">{{ stripped_name }}</p>
                 {%- if contributors[contributor].affiliation %}
-                <p class="card-affiliation">{{ contributors[contributor].affiliation | join: ", " }}</p>
+                <p class="card-affiliation">{{ contributors[contributor].affiliation | join: " / " }}</p>
                 {%- endif %}
               </div>
               {%- if contributors[contributor].git or contributors[contributor].email or contributors[contributor].orcid %}

--- a/_includes/contributor-tiles-all.html
+++ b/_includes/contributor-tiles-all.html
@@ -76,7 +76,7 @@
       <div class="card-body text-center py-0">
         <p class="card-title">{{ contributor }}</p>
         {%- if contributors[contributor].affiliation %}
-        <p class="card-affiliation">{{ contributors[contributor].affiliation }}</p>
+        <p class="card-affiliation">{{ contributors[contributor].affiliation | join: ", " }}</p>
         {%- endif %}
       </div>
       {%- if contributors[contributor].git or contributors[contributor].email or contributors[contributor].orcid %}

--- a/_includes/contributor-tiles-all.html
+++ b/_includes/contributor-tiles-all.html
@@ -76,7 +76,7 @@
       <div class="card-body text-center py-0">
         <p class="card-title">{{ contributor }}</p>
         {%- if contributors[contributor].affiliation %}
-        <p class="card-affiliation">{{ contributors[contributor].affiliation | join: ", " }}</p>
+        <p class="card-affiliation">{{ contributors[contributor].affiliation | join: " / " }}</p>
         {%- endif %}
       </div>
       {%- if contributors[contributor].git or contributors[contributor].email or contributors[contributor].orcid %}

--- a/_includes/schemasorg.html
+++ b/_includes/schemasorg.html
@@ -19,7 +19,7 @@
                 {%- if contributors[people].affiliation %}
                 "affiliation": {
                     "@type": "Organization",
-                    "name": "{{contributors[people].affiliation | join: ", "}}"
+                    "name": "{{contributors[people].affiliation | join: " / "}}"
                 },
                 {%- endif %}
                 {%- if contributors[people].email %}

--- a/_includes/schemasorg.html
+++ b/_includes/schemasorg.html
@@ -19,7 +19,7 @@
                 {%- if contributors[people].affiliation %}
                 "affiliation": {
                     "@type": "Organization",
-                    "name": "{{contributors[people].affiliation}}"
+                    "name": "{{contributors[people].affiliation | join: ", "}}"
                 },
                 {%- endif %}
                 {%- if contributors[people].email %}

--- a/pages/example_pages/general_page.md
+++ b/pages/example_pages/general_page.md
@@ -1,7 +1,7 @@
 ---
 title: General page example
 type: example_pages
-contributors: [Bert Droesbeke, Long Example Contributor , Example Contributor, Example Contributor, Example Contributor, Example Contributor, Example Contributor, Example Contributor, Example Contributor]
+contributors: [Bert Droesbeke, Long Example Contributor , Example Contributor, Example Contributor2, Example Contributor3]
 coordinators: [Bert Droesbeke] 
 description: This description is used when the page is listed
 page_id: gp1

--- a/pages/example_pages/general_page_5.md
+++ b/pages/example_pages/general_page_5.md
@@ -1,7 +1,7 @@
 ---
 title: General page example 5
 type: example_pages
-contributors: [Bert Droesbeke, Long Example Contributor , Example Contributor, Example Contributor, Example Contributor, Example Contributor, Example Contributor, Example Contributor, Example Contributor]
+contributors: [Bert Droesbeke, Long Example Contributor , Example Contributor, Example Contributor2, Example Contributor3]
 coordinators: [Bert Droesbeke] 
 description: This description is used when the page is listed
 page_id: gp5

--- a/pages/example_pages/general_page_6.md
+++ b/pages/example_pages/general_page_6.md
@@ -1,7 +1,7 @@
 ---
 title: General page example 5
 type: example_pages
-contributors: [Bert Droesbeke, Long Example Contributor , Example Contributor, Example Contributor, Example Contributor, Example Contributor, Example Contributor, Example Contributor, Example Contributor]
+contributors: [Bert Droesbeke, Long Example Contributor , Example Contributor, Example Contributor2, Example Contributor3]
 coordinators: [Bert Droesbeke] 
 description: This description is used when the page is listed
 sidebar: false

--- a/pages/example_pages/general_page_7.md
+++ b/pages/example_pages/general_page_7.md
@@ -1,7 +1,6 @@
 ---
 title: General page example 7
 type: example_pages
-contributors: [Bert Droesbeke, Long Example Contributor , Example Contributor, Example Contributor, Example Contributor, Example Contributor, Example Contributor, Example Contributor, Example Contributor]
 coordinators: [Bert Droesbeke] 
 description: This description is used when the page is listed
 page_id: gp7


### PR DESCRIPTION
Fixes #311.

Tested at https://github.com/anenadic/RSQKit/tree/affiliation-as_list.