### PR TITLE
add option for disabling Matomo cookies

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -20,7 +20,7 @@ matomo:
 # Matomo domain where Matomo is running
 matomo_id:
 # Integer indicating the Matomo Website ID
-matomo_cookies: false
+matomo_cookies: true
 # Boolean that determines whether a Matomo tracking cookie is used or not
 
 plausible: 

--- a/_config.yml
+++ b/_config.yml
@@ -20,6 +20,8 @@ matomo:
 # Matomo domain where Matomo is running
 matomo_id:
 # Integer indicating the Matomo Website ID
+matomo_cookies: false
+# Boolean that determines whether a Matomo tracking cookie is used or not
 
 plausible: 
 # Plausible tag

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -124,7 +124,7 @@
     <script>
         var _paq = window._paq = window._paq || [];
         /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
-        {%- unless site.matomo_cookies %}
+        {%- if site.matomo_cookies == false %}
         _paq.push(['disableCookies']);
         {%- endunless %}
         _paq.push(['trackPageView']);

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -124,6 +124,9 @@
     <script>
         var _paq = window._paq = window._paq || [];
         /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
+        {%- unless site.matomo_cookies %}
+        _paq.push(['disableCookies']);
+        {%- endunless %}
         _paq.push(['trackPageView']);
         _paq.push(['enableLinkTracking']);
         (function() {

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -126,7 +126,7 @@
         /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
         {%- if site.matomo_cookies == false %}
         _paq.push(['disableCookies']);
-        {%- endunless %}
+        {%- endif %}
         _paq.push(['trackPageView']);
         _paq.push(['enableLinkTracking']);
         (function() {

--- a/pages/documentation/configuring_theme.md
+++ b/pages/documentation/configuring_theme.md
@@ -29,6 +29,8 @@ matomo:
 # Matomo domain where Matomo is running
 matomo_id:
 # Integer indicating the Matomo Website ID
+matomo_cookies: false
+# Boolean that determines whether a Matomo tracking cookie is used or not
 
 plausible: 
 # Plausible tag

--- a/pages/documentation/configuring_theme.md
+++ b/pages/documentation/configuring_theme.md
@@ -29,7 +29,7 @@ matomo:
 # Matomo domain where Matomo is running
 matomo_id:
 # Integer indicating the Matomo Website ID
-matomo_cookies: false
+matomo_cookies: true
 # Boolean that determines whether a Matomo tracking cookie is used or not
 
 plausible: 


### PR DESCRIPTION
In RSQKit we want to disable Matomo cookies for now. This makes the site more easily GDPR compliant (without cookie wall). It only takes a single added line of JS, which this commit adds.