### PR TITLE
Add 'how to cite this page' section to page layout

### DIFF
--- a/_includes/citation-page.html
+++ b/_includes/citation-page.html
@@ -11,9 +11,9 @@
     {% assign page_url = page.url | absolute_url %}
     <a href="{{ page_url }}">{{ page_url }}</a> <span id="current_date"></span>.
 </p>
-{% endif %}
-
 <script>
     var current_date = new Date().toLocaleDateString('en-uk', { year:"numeric", month:"long", day:"numeric"})
     document.getElementById("current_date").textContent = "(accessed " + current_date + ")";
 </script>
+{% endif %}
+

--- a/_includes/citation-page.html
+++ b/_includes/citation-page.html
@@ -1,6 +1,6 @@
-{% if page.title %}
+{% if page.page_citation and page.title %}
 <h2>How to cite this page</h2>
-<div>
+<p>
     {% if page.contributors %}
     {{ page.contributors | join: ", " }},
     {% endif %}
@@ -10,7 +10,7 @@
     {% endif %}
     {% assign page_url = page.url | absolute_url %}
     <a href="{{ page_url }}">{{ page_url }}</a> <span id="current_date"></span>.
-</div>
+</p>
 {% endif %}
 
 <script>

--- a/_includes/citation-page.html
+++ b/_includes/citation-page.html
@@ -6,7 +6,7 @@
     {% endif %}
     "<em>{{ page.title }}</em>".
     {% if site.url %}
-    {{ site.url }}.
+    {{ site.url | remove: "https://www." | remove: "http://www." | remove: "https://" | remove: "http://"  }}.
     {% endif %}
     {% assign page_url = page.url | absolute_url %}
     <a href="{{ page_url }}">{{ page_url }}</a> <span id="current_date"></span>.

--- a/_includes/citation.html
+++ b/_includes/citation.html
@@ -2,11 +2,13 @@
 <h2>How to cite this page</h2>
 <div>
     {% if page.contributors %}
-        {{ page.contributors | join: ", " }}.
+        {{ page.contributors | join: ", " }},
     {% endif %}
-    <strong>{{ page.title }} ({{ site.title }} material)</strong>.
+    "<em>{{ page.title }}</em>".
+    {% if site.url %}
+        {{ site.url }}.
+    {% endif %}
     {% assign page_url = page.url | absolute_url %}
-    Online: <a href="{{ page_url }}">{{ page_url }}</a>.
-    Accessed {{ site.time | date: "%d %B, %Y" }}.
+    <a href="{{ page_url }}">{{ page_url }}</a> (accessed {{ site.time | date: "%d %B, %Y" }}).
 </div>
 {% endif %}

--- a/_includes/citation.html
+++ b/_includes/citation.html
@@ -2,13 +2,18 @@
 <h2>How to cite this page</h2>
 <div>
     {% if page.contributors %}
-        {{ page.contributors | join: ", " }},
+    {{ page.contributors | join: ", " }},
     {% endif %}
     "<em>{{ page.title }}</em>".
     {% if site.url %}
-        {{ site.url }}.
+    {{ site.url }}.
     {% endif %}
     {% assign page_url = page.url | absolute_url %}
-    <a href="{{ page_url }}">{{ page_url }}</a> (accessed {{ site.time | date: "%d %B, %Y" }}).
+    <a href="{{ page_url }}">{{ page_url }}</a> <span id="current_date"></span>.
 </div>
 {% endif %}
+
+<script>
+    var current_date = new Date().toLocaleDateString('en-uk', { year:"numeric", month:"long", day:"numeric"})
+    document.getElementById("current_date").textContent = "(accessed " + current_date + ")";
+</script>

--- a/_includes/citation.html
+++ b/_includes/citation.html
@@ -4,7 +4,7 @@
     {% if page.contributors %}
         {{ page.contributors | join: ", " }}.
     {% endif %}
-    <strong>{{ page.title }} (Research Software Quality Kit (RSQKit) material)</strong>.
+    <strong>{{ page.title }} ({{ site.title }} material)</strong>.
     {% assign page_url = page.url | absolute_url %}
     Online: <a href="{{ page_url }}">{{ page_url }}</a>.
     Accessed {{ site.time | date: "%d %B, %Y" }}.

--- a/_includes/citation.html
+++ b/_includes/citation.html
@@ -1,0 +1,12 @@
+{% if page.title %}
+<h2>How to cite this page</h2>
+<div>
+    {% if page.contributors %}
+        {{ page.contributors | join: ", " }}.
+    {% endif %}
+    <strong>{{ page.title }} (Research Software Quality Kit (RSQKit) material)</strong>.
+    {% assign page_url = page.url | absolute_url %}
+    Online: <a href="{{ page_url }}">{{ page_url }}</a>.
+    Accessed {{ site.time | date: "%d %B, %Y" }}.
+</div>
+{% endif %}

--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -34,7 +34,9 @@ layout: default
         {%- endif %}
         {% include affiliation-tiles-page.html %}
         {% include contributor-minitiles-page.html %}
+        {% if page.include_citation %}
         {% include citation.html %}
+        {% endif %}
         {%- if site.theme_variables.github_buttons.position == "bottom" %}
         <div id="github-buttons-wrapper" class="d-flex mt-5">
         {% include github-buttons.html %}

--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -34,9 +34,7 @@ layout: default
         {%- endif %}
         {% include affiliation-tiles-page.html %}
         {% include contributor-minitiles-page.html %}
-        {% if page.include_citation %}
-        {% include citation.html %}
-        {% endif %}
+        {% include citation-page.html %}
         {%- if site.theme_variables.github_buttons.position == "bottom" %}
         <div id="github-buttons-wrapper" class="d-flex mt-5">
         {% include github-buttons.html %}

--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -34,6 +34,7 @@ layout: default
         {%- endif %}
         {% include affiliation-tiles-page.html %}
         {% include contributor-minitiles-page.html %}
+        {% include citation.html %}
         {%- if site.theme_variables.github_buttons.position == "bottom" %}
         <div id="github-buttons-wrapper" class="d-flex mt-5">
         {% include github-buttons.html %}

--- a/pages/documentation/page_mechanics.md
+++ b/pages/documentation/page_mechanics.md
@@ -45,8 +45,7 @@ It is important to know that you can also set the these key-value pairs on multi
 
 * `type`: The type of page, used for [website sections](website_sections).
 
-* `page_citation`: When set to true, it will cause the citation section for the page to be generated in the format:
-`<author names>. <page title> (<site name> material). Online: <page URL>. Accessed: <date>`.
+* `page_citation`: When set to true, it will cause the citation section for the page to be generated in the format: `<author names>. <page title>. <site domain>. <page URL>. <date accessed>.`
 
 ### Related pages
 

--- a/pages/documentation/page_mechanics.md
+++ b/pages/documentation/page_mechanics.md
@@ -45,7 +45,7 @@ It is important to know that you can also set the these key-value pairs on multi
 
 * `type`: The type of page, used for [website sections](website_sections).
 
-* `include_citation`: When set to true, it will cause the citation section for the page to be generated in the format:
+* `page_citation`: When set to true, it will cause the citation section for the page to be generated in the format:
 `<author names>. <page title> (<site name> material). Online: <page URL>. Accessed: <date>`.
 
 ### Related pages

--- a/pages/documentation/page_mechanics.md
+++ b/pages/documentation/page_mechanics.md
@@ -45,7 +45,8 @@ It is important to know that you can also set the these key-value pairs on multi
 
 * `type`: The type of page, used for [website sections](website_sections).
 
-
+* `include_citation`: When set to true, it will cause the citation section for the page to be generated in the format:
+`<author names>. <page title> (<site name> material). Online: <page URL>. Accessed: <date>`.
 
 ### Related pages
 

--- a/pages/example_pages/general_page_7.md
+++ b/pages/example_pages/general_page_7.md
@@ -5,6 +5,7 @@ contributors: [Bert Droesbeke, Long Example Contributor , Example Contributor, E
 coordinators: [Bert Droesbeke] 
 description: This description is used when the page is listed
 page_id: gp7
+page_citation: true
 ---
 
 


### PR DESCRIPTION
Automated generation of citation information (in the [IEEE Web-based document or source format](https://libraryguides.vu.edu.au/ieeereferencing/webbaseddocument#:~:text=Basic%20format%20to%20reference%20a%20web%2Dbased%20document%20or%20source,Address%20(accessed%20date%20retrieved))) for each page in a new "How to cite this page" section at the bottom, to look like the following:

<img width="1038" alt="image" src="https://github.com/user-attachments/assets/13cff4f0-bfde-43fc-bd47-68c76141b6fb" />


A parameter is needed to control if the citation info is added to the page or not (and defaults to false for backward compatibility) and also so that citation does not show on other pages using the "page" layout. For example, in `_config.yaml`:
```yml
  -
    scope:
      path: "pages/your_tasks/"
    values:
      type: your_tasks
      type_img: /assets/img/section-icons/tick.svg
      include_citation: true
```
We'd need to update the page metadata documenation at: https://rdmkit.elixir-europe.org/page_metadata too.
I did not apply any CSS styles to the added citation div. 
