### PR TITLE
Add other social media links in _config.yml

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -87,7 +87,7 @@ theme_variables:
     # twitter: false
     # bluesky: false
     # linkedin: false
-    # fosstodon: false
+    # mastodon: false
   # theme_color: 0d6efd
   # fonts:
   #   - url towards a font

--- a/_config.yml
+++ b/_config.yml
@@ -87,7 +87,7 @@ theme_variables:
     # twitter: false
     # bluesky: false
     # linkedin: false
-    # mastodon: false
+    # fosstodon: false
   # theme_color: 0d6efd
   # fonts:
   #   - url towards a font

--- a/_config.yml
+++ b/_config.yml
@@ -85,6 +85,9 @@ theme_variables:
     # brand_logo: assets/img/main_logo.svg
     # github: true
     # twitter: false
+    # bluesky: false
+    # linkedin: false
+    # fosstodon: false
   # theme_color: 0d6efd
   # fonts:
   #   - url towards a font

--- a/_includes/topnav.html
+++ b/_includes/topnav.html
@@ -56,6 +56,21 @@
                         <a class="nav-link ps-2 d-flex align-items-center" href="{{site.theme_variables.topnav.twitter}}"><i class="fa-brands fa-x-twitter me-2"></i>Twitter</a>
                     </li>
                     {%- endif %}
+                    {%- if site.theme_variables.topnav.bluesky %}
+                    <li class="nav-item">
+                        <a class="nav-link ps-2 d-flex align-items-center" href="{{site.theme_variables.topnav.bluesky}}"><i class="fa-brands fa-bluesky me-2"></i>Bluesky</a>
+                    </li>
+                    {%- endif %}
+                    {%- if site.theme_variables.topnav.fosstodon %}
+                    <li class="nav-item">
+                        <a class="nav-link ps-2 d-flex align-items-center" href="{{site.theme_variables.topnav.fosstodon}}"><i class="fa-brands fa-mastodon me-2"></i>FOSStodon</a>
+                    </li>
+                    {%- endif %}
+                    {%- if site.theme_variables.topnav.linkedin %}
+                    <li class="nav-item">
+                        <a class="nav-link ps-2 d-flex align-items-center" href="{{site.theme_variables.topnav.linkedin}}"><i class="fa-brands fa-linkedin me-2"></i>LinkedIn</a>
+                    </li>
+                    {%- endif %}
                     {%- if site.theme_variables.topnav.github or site.theme_variables.topnav.github == nil %}
                     <li class="nav-item">
                         <a class="nav-link ps-2 d-flex align-items-center" href="{{site.github.repository_url}}">

--- a/pages/documentation/configuring_theme.md
+++ b/pages/documentation/configuring_theme.md
@@ -71,6 +71,9 @@ theme_variables:
     brand_logo: assets/img/main_logo.svg
     github: true
     twitter: false
+    bluesky: false
+    linkedin: false
+    fosstodon: false
   theme_color: 0d6efd
   fonts:
     - url towards a font
@@ -104,5 +107,8 @@ More detailed information about these settings can be found here:
   *  `brand_logo`: Custom path towards the brand logo, in case the assets/img/main_logo.svg can not be used.
   *  `github`: Enable or disable the appearance of the Github repo nav link. Default: *true*
   *  `twitter`: Enable or disable the appearance of the Twitter nav link by adding the url towards the twitter page. Default: *false*
+  *  `bluesky`: Enable or disable the appearance of the Bluesky nav link by adding the url towards the Bluesky page. Default: *false*
+  *  `linkedin`: Enable or disable the appearance of the Linkedin nav link by adding the url towards the Linkedin page. Default: *false*
+  *  `fosstodon`: Enable or disable the appearance of the Fosstodon nav link by adding the url towards the Fosstodon page. Default: *false*
 * `theme_color`: This is the primary theme color which is used in the metadata of the website. Please use the hex color without the hashtag as value.
 * `fonts`: List here the urls towards google fonts to include custom fonts for your website.


### PR DESCRIPTION
Fixes #321.

Adding 3 new options in the _config.yml file:

```yml
theme_variables: 
  topnav:
    bluesky: false
    linkedin: false
    fosstodon: false
```

  *  `bluesky`: Enable or disable the appearance of the Bluesky nav link by adding the url towards the Bluesky page. Default: *false*
  *  `linkedin`: Enable or disable the appearance of the Linkedin nav link by adding the url towards the Linkedin page. Default: *false*
  *  `fosstodon`: Enable or disable the appearance of the Fosstodon nav link by adding the url towards the Fosstodon page. Default: *false*