### PR TITLE
Making page type case sensitive

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -30,7 +30,7 @@
     <meta name="robots" content="noindex" />
     {%- endif %}
     {%- if page.type %}
-    {%- assign subtitle = page.type | replace: "_", " " | capitalize %}
+    {%- assign subtitle = page.type | replace: "_", " " %}
     {%- endif %}
     <title>{% if page.title %}{% if subtitle %}{{subtitle}}: {% endif %}{{ page.title }} | {{ site.title }}{%- else %}{{ site.title }}{% endif %}</title>
     <!-- Syntax highlighting  -->

--- a/_includes/related-pages.html
+++ b/_includes/related-pages.html
@@ -23,7 +23,7 @@
                     <img src="{{page_hit.type_img | relative_url}}" class="type-icon me-2" alt="{{page_hit.type}} icon">
                     {%- endif %}
                     {%- if page_hit.type %}
-                    <span class=""><small>{{page_hit.type | replace: "_", " " | capitalize }}</small></span>
+                    <span class=""><small>{{page_hit.type | replace: "_", " " }}</small></span>
                     {%- endif %}
                 </div>
                 <a class="stretched-link section-title" aria-label="Go to the {{page_hit.title}} page" href="{{ page_hit.url | relative_url }}">

--- a/_includes/resource-table-all.html
+++ b/_includes/resource-table-all.html
@@ -92,7 +92,7 @@
                 {%- for tag in tool.related_pages %}
                 {%- unless tag == page.page_id %}
                 {%- assign related_page = site.pages | where:"page_id",tag | first %}
-                <a href="{{related_page.url | relative_url }}" data-bs-toggle="tooltip" title="{{related_page.type | replace: '_', ' ' | capitalize }}"><span class="badge default-badge">{{ related_page.title | truncate: 25 }}</span></a>
+                <a href="{{related_page.url | relative_url }}" data-bs-toggle="tooltip" title="{{related_page.type | replace: '_', ' ' }}"><span class="badge default-badge">{{ related_page.title | truncate: 25 }}</span></a>
                 {%- endunless %}
                 {%- endfor %}
                 {%- endcapture %}

--- a/_includes/resource-table-page.html
+++ b/_includes/resource-table-page.html
@@ -47,7 +47,7 @@
                 {%- for tag in section[1] %}
                 {%- unless tag == page.page_id %}
                 {%- assign related_page = site.pages | where:"page_id",tag | first %}
-                <a class="nohover" href="{{related_page.url | relative_url }}"  data-bs-toggle="tooltip" title="{{related_page.type | replace: '_', ' ' | capitalize}}"><span class="badge default-badge">{{ related_page.title | truncate: 25 }}</span></a>
+                <a class="nohover" href="{{related_page.url | relative_url }}"  data-bs-toggle="tooltip" title="{{related_page.type | replace: '_', ' ' }}"><span class="badge default-badge">{{ related_page.title | truncate: 25 }}</span></a>
                 {%- endunless %}
                 {%- endfor %}
                 {%- endunless %}
@@ -126,7 +126,7 @@
                 {%- for tag in tool.related_pages %}
                 {%- unless tag == page.page_id %}
                 {%- assign related_page = site.pages | where:"page_id",tag | first %}
-                <a href="{{related_page.url | relative_url }}"  data-bs-toggle="tooltip" title="{{related_page.type | replace: '_', ' ' | capitalize}}"><span class="badge default-badge">{{ related_page.title | truncate: 25 }}</span></a>
+                <a href="{{related_page.url | relative_url }}"  data-bs-toggle="tooltip" title="{{related_page.type | replace: '_', ' ' }}"><span class="badge default-badge">{{ related_page.title | truncate: 25 }}</span></a>
                 {%- endunless %}
                 {%- endfor %}
                 {%- endcapture %}

--- a/_includes/section-navigation-tiles.html
+++ b/_includes/section-navigation-tiles.html
@@ -37,7 +37,7 @@
     <div class="col">
         <div class="input-group">
             <span class="input-group-text" id="search-label-tiles"><i class="fa-solid fa-magnifying-glass"></i></span>
-            <input type="text" id="title-search" class="form-control" onkeyup="StartSearch();" placeholder="Find your page..." aria-label="{{page.type | replace: '_', ' ' |}}" aria-describedby="search-label-tiles">
+            <input type="text" id="title-search" class="form-control" onkeyup="StartSearch();" placeholder="Find your page..." aria-label="{{page.type | replace: '_', ' ' }}" aria-describedby="search-label-tiles">
             <button class="btn btn-primary" title="Button to clear search" type="button" id="clearsearch">
                 <i class="fa-solid fa-backspace"></i>
             </button>
@@ -90,7 +90,7 @@
                     <img src="{{current_page.type_img | relative_url}}" class="type-icon me-2" alt="{{current_page.type}} icon">
                     {%- endif %}
                     {%- if current_page.type %}
-                    <span class=""><small>{{current_page.type | replace: "_", " " | capitalize }}</small></span>
+                    <span class=""><small>{{current_page.type | replace: "_", " " }}</small></span>
                     {%- endif %}
                 </div>
                 <a class="stretched-link section-title" aria-label="Go to the {{current_page.title}} page" href="{{ current_page.url | relative_url }}">

--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -8,7 +8,7 @@ layout: default
         {%- endif %}
         {%- if page.title %}
         {%- if page.type and site.theme_variables.breadcrumb != true %}
-        {%- assign subtitle = page.type | replace: "_", " " | capitalize %}
+        {%- assign subtitle = page.type | replace: "_", " " %}
         <h1 class="has-subtitle order-1 order-md-0"><span class="d-block text-secondary fs-4 ff-body">{{subtitle}}</span><span class="visually-hidden">:</span> {{ page.title }}
         {%- else %}
         <h1>{{ page.title }}

--- a/pages/example_pages/TEMPLATE_general_page.md
+++ b/pages/example_pages/TEMPLATE_general_page.md
@@ -1,6 +1,6 @@
 ---
 title: Template example
-type: example_pages
+type: Example_pages
 contributors: [Bert Droesbeke]
 search_exclude: true
 sitemap: false

--- a/pages/example_pages/general_page.md
+++ b/pages/example_pages/general_page.md
@@ -1,6 +1,6 @@
 ---
 title: General page example
-type: example_pages
+type: Example_pages
 contributors: [Bert Droesbeke, Long Example Contributor , Example Contributor, Example Contributor2, Example Contributor3]
 coordinators: [Bert Droesbeke] 
 description: This description is used when the page is listed

--- a/pages/example_pages/general_page_2.md
+++ b/pages/example_pages/general_page_2.md
@@ -1,6 +1,6 @@
 ---
 title: General page example 2
-type: example_pages
+type: Example_pages
 type_img: /assets/img/ett_compact_logo_bw.svg
 page_img: infrastructures/ELIXIR_BELGIUM_white_background.svg 
 contributors: [Bert Droesbeke]

--- a/pages/example_pages/general_page_3.md
+++ b/pages/example_pages/general_page_3.md
@@ -1,6 +1,6 @@
 ---
 title: General page example 3
-type: example_pages
+type: Example_pages
 description: This page has page level resources
 country_code: BE
 page_id: gp3

--- a/pages/example_pages/general_page_4.md
+++ b/pages/example_pages/general_page_4.md
@@ -1,6 +1,6 @@
 ---
 title: General page example 4
-type: example_pages
+type: Example_pages
 description: This page has no more information
 page_img: infrastructures/ELIXIR_BELGIUM_white_background.svg 
 page_id: gp4

--- a/pages/example_pages/general_page_5.md
+++ b/pages/example_pages/general_page_5.md
@@ -1,6 +1,6 @@
 ---
 title: General page example 5
-type: example_pages
+type: Example_pages
 contributors: [Bert Droesbeke, Long Example Contributor , Example Contributor, Example Contributor2, Example Contributor3]
 coordinators: [Bert Droesbeke] 
 description: This description is used when the page is listed

--- a/pages/example_pages/general_page_6.md
+++ b/pages/example_pages/general_page_6.md
@@ -1,6 +1,6 @@
 ---
 title: General page example 5
-type: example_pages
+type: Example_pages
 contributors: [Bert Droesbeke, Long Example Contributor , Example Contributor, Example Contributor2, Example Contributor3]
 coordinators: [Bert Droesbeke] 
 description: This description is used when the page is listed

--- a/pages/example_pages/general_page_7.md
+++ b/pages/example_pages/general_page_7.md
@@ -1,6 +1,6 @@
 ---
 title: General page example 7
-type: example_pages
+type: Example_pages
 coordinators: [Bert Droesbeke]
 description: This description is used when the page is listed
 page_id: gp7

--- a/pages/example_pages/overview_tiles.md
+++ b/pages/example_pages/overview_tiles.md
@@ -5,4 +5,4 @@ toc: false
 
 More info about sections tiles can be found in the [website sections page](website_sections).
 
-{% include section-navigation-tiles.html type="example_pages" affiliations=true search=true except="index.md" %}
+{% include section-navigation-tiles.html type="Example_pages" affiliations=true search=true except="index.md" %}


### PR DESCRIPTION
This change should allow the use of section titles (types) with acronyms or more complex use of capital letters then just the first letter of the section title to be capitalised. 

🚨 BREAKING CHANGE 🚨
When no action will be taken, section titles (types) will be displayed lower case from now on.
How to prevent this: 
* Page types for sections set on page level or website (config.yml) level need to be capitalised where needed
* `section-navigation-tiles-simple.html` and `section-navigation-tiles.html` includes: The type param needs to be updated according to the one set on page/website level

This would close #223 