### PR TITLE
Make pagelength of Datatables configurable

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -70,7 +70,8 @@ theme_variables:
   #   open_issue: true
   #   history: true
   # datatables:
-  #   searchbuilder: True
+  #   searchbuilder: false
+    # pagelength: 10
   # headings:
   #   related-pages: Related pages
   #   more-information-tiles: More information

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -73,11 +73,12 @@
     <script type="text/javascript" charset="utf8" src="{{ 'assets/js/dataTables.dateTime.min.js' | relative_url }}"></script>
     <script type="text/javascript" charset="utf8" src="{{ 'assets/js/searchBuilder.bootstrap5.min.js' | relative_url }}"></script>
     {%- endif %}
+    {%- assign pagelength = site.theme_variables.datatables.pagelength | default: 10 %}
     <script type="text/javascript">
         $(document).ready(function () {
             $('table.display').each(function() {
                 $(this).DataTable({
-                    lengthMenu: [[10, 25, 50, 100, -1], [10, 25, 50, 100, "All"]],
+                    lengthMenu: [[{{ pagelength }}, {{ pagelength | times: 2 }}, {{ pagelength | times: 5 }}, {{ pagelength | times: 10 }}, -1], [{{ pagelength }}, {{ pagelength | times: 2 }}, {{ pagelength | times: 5 }}, {{ pagelength | times: 10 }}, "All"]],
                     stateSave: true,
                     searching: true,
                     {%- if site.theme_variables.datatables.searchbuilder %}
@@ -86,13 +87,13 @@
                     },
                     {%- endif %}
                     info: true,
-                    pageLength: 10,
+                    pageLength: {{ pagelength }},
                     language: {
                         searchPlaceholder: "Type here..."
                     },
                     "drawCallback": function ( settings ){
                         var tableId = settings.nTable.id;
-                        if(settings.fnRecordsTotal() < 10){     
+                        if(settings.fnRecordsTotal() < {{ pagelength }}){     
                             $('#'+tableId+'_wrapper .dt-length').hide();
                             $('#'+tableId+'_wrapper .dt-paging').hide();
                             $('#'+tableId+'_wrapper .dt-search').hide();

--- a/pages/documentation/configuring_theme.md
+++ b/pages/documentation/configuring_theme.md
@@ -55,7 +55,8 @@ theme_variables:
     open_issue: true
     history: true
   datatables:
-    searchbuilder: False
+    searchbuilder: false
+    pagelength: 10
   headings:
     related-pages: Related pages
     more-information-tiles: More information
@@ -92,7 +93,8 @@ More detailed information about these settings can be found here:
   * `open_issue`: Enable the 'open an issue on this page' button.
   * `history`: Enable the 'history of this page' button.
 * **datatables**: Settings related to the DataTables JS library
-  * `searchbuilder`: SearchBuilder provides the end user with an easy to use UI for them to create their own complex custom search expression for a DataTable. Default: False.
+  * `searchbuilder`: SearchBuilder provides the end user with an easy to use UI for them to create their own complex custom search expression for a DataTable. Default: *false*.
+  * `pagelength`: Number of rows to display on a single page. Dropdown for entries per page is a list of *pagelength* times 2,5 and 10. Default: *10*.
 * **headings**: Change the subtitles or collapse the page sections that are automatically generated
     `related-pages`: Default: Related pages
     `more-information-tiles`:  Default: More information


### PR DESCRIPTION
This will close #251 .

And adds the new setting:

```yml
theme_variables:
  datatables:
    pagelength: 10
```

  * `pagelength`: Number of rows to display on a single page. Dropdown for entries per page is a list of *pagelength* times 2,5 and 10. Default: *10*.
