### PR TITLE
Add ability to disable website search 

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -85,6 +85,7 @@ theme_variables:
   # topnav:
     # theme: light
     # brand_logo: assets/img/main_logo.svg
+    # search: true
     # github: true
     # twitter: false
     # bluesky: false

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -59,7 +59,9 @@
     {% if page.toc or page.toc == nil %}<script src="{{ 'assets/js/toc.js' | relative_url }}?{{site.time | date: '%s'}}"></script>{% endif %}
     <script src="{{ 'assets/js/jquery.navgoco.js' | relative_url }}"></script>
     <script src="{{ 'assets/js/main.js' | relative_url }}?{{site.time | date: '%s'}}"></script>
+    {%- unless site.theme_variables.topnav.search == false  %}
     <script src="{{ 'assets/js/search.js' | relative_url }}"></script>
+    {%- endunless %}
     <script src="{{ 'assets/js/clipboard.min.js' | relative_url }}"></script>
     {%- if page.datatable == true %}
     <!-- Include the standard DataTables bits -->

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -4,7 +4,7 @@
 <body class="d-flex flex-column min-vh-100"{% if page.toc or page.toc == nil %} data-bs-spy="scroll" data-bs-target="#toc-contents" data-bs-smooth-scroll="true" tabindex="0"{% endif %}>
     {% if site.topnav_banner %}{% include banner.html %}{% endif %}
     {% if jekyll.environment == "development" and site.theme_variables.dev-info-banner == true %}{% include dev-info.html %}{% endif %}
-    {% include topnav.html %}
+    {% include topnav.html search=site.theme_variables.topnav.search %}
     <!-- Page Content -->
     <div class="container g-lg-5 flex-grow-1">
         <!-- Content Row -->

--- a/pages/documentation/configuring_theme.md
+++ b/pages/documentation/configuring_theme.md
@@ -70,6 +70,7 @@ theme_variables:
   topnav:
     theme: light
     brand_logo: assets/img/main_logo.svg
+    search: true
     github: true
     twitter: false
     bluesky: false
@@ -108,6 +109,7 @@ More detailed information about these settings can be found here:
 * **topnav**: Settings related to the top navigation.
   *  `theme`: This variable is needed to change between a dark and a light top navigation. possible values: *dark* and *light*
   *  `brand_logo`: Custom path towards the brand logo, in case the assets/img/main_logo.svg can not be used.
+  *  `search`:  Enable or disable the appearance of the search bar. Default: *true*
   *  `github`: Enable or disable the appearance of the Github repo nav link. Default: *true*
   *  `twitter`: Enable or disable the appearance of the Twitter nav link by adding the url towards the twitter page. Default: *false*
   *  `bluesky`: Enable or disable the appearance of the Bluesky nav link by adding the url towards the Bluesky page. Default: *false*


### PR DESCRIPTION
New configuration in the `_config.yml` file:

```yml
theme_variables:
  topnav:
    search: true
 ```
 
 *  `search`:  Enable or disable the appearance of the search bar. Default: *true*
 
 