### PR TITLE
Revert 1700px breakpoint of main container

### DIFF
--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -37,7 +37,7 @@ $navbar-dark-toggler-border-color: transparent !default;
 $link-decoration: none  !default;
 $link-color: $primary !default;
 $custom-container-max-widths: (
-    xxxl: 1440px
+    xxxl: 1700px
 );
 
 


### PR DESCRIPTION
This introduced a problem in RDMkit with the all tools and resources table, see https://github.com/elixir-europe/rdmkit/pull/1751