### PR TITLE
Add support for `related_pages` parameter to the events include

### DIFF
--- a/_data/events.yml
+++ b/_data/events.yml
@@ -15,6 +15,7 @@
   startTime: '9:00'
   endDate: 2030-06-24
   endTime: 13:30 CET
+  related_pages: [gp5]
   description: >
    Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean magna massa, vestibulum ut leo eget, fermentum molestie mauris. Cras facilisis libero non sodales lobortis. Proin eu ultricies lacus. Sed posuere orci id tincidunt sollicitudin. Phasellus sit amet justo turpis. Vestibulum non volutpat libero. Donec mattis elementum sem nec posuere. Donec vitae libero sed mi faucibus tempus.
    Talks included<span>:</span>

--- a/_includes/events.html
+++ b/_includes/events.html
@@ -8,6 +8,7 @@
   {%- else %}
   {%- assign events = site.data.events | sort: "startDate" | reverse %}
     {%- endif %}
+  {%- assign count = 0 %}
   <ul class="list-unstyled mt-3">
     {%- for event in events %}
     <li class='{{include.event_type}}' data-start='{{ event.startDate}}'>

--- a/_includes/events.html
+++ b/_includes/events.html
@@ -2,8 +2,12 @@
   {%- if include.title == true%}
   <h2>{{include.event_type | replace: "_", " " | capitalize}}s</h2>
   {%- endif %}
+  {%- if include.related_pages %}
+  {%- assign filtered = site.data.events | where_exp: "event", "event.related_pages contains include.related_pages" %}
+  {%- assign events = filtered | sort: "startDate" | reverse %}
+  {%- else %}
   {%- assign events = site.data.events | sort: "startDate" | reverse %}
-  {%- assign count = 0 %}
+    {%- endif %}
   <ul class="list-unstyled mt-3">
     {%- for event in events %}
     <li class='{{include.event_type}}' data-start='{{ event.startDate}}'>

--- a/pages/example_pages/events.md
+++ b/pages/example_pages/events.md
@@ -34,7 +34,17 @@ Becomes:
 * `caption_url`: Add a custom url if the main events page is not served at */events*
 * `truncate`: If longer event descriptions are used and this parameter is set to *true*, descriptions which are longer than 40 words will get collapsed behind a button (`true` or `false`).
 * `limit`: Integer to determine the amount of news items shown.
+* `related_pages`: A `page_id` assigned to the events that should be displayed. Add the same ID to each event's `related_pages` list in `_data/events.yml`.
+
+## Filter events by related page
 
 
+```
+{% raw %}
+{% include events.html event_type="upcoming_event" related_pages="gp5" %}
+{% endraw %}
+```
 
+Becomes:
 
+{% include events.html event_type="upcoming_event" related_pages="gp5" %}


### PR DESCRIPTION
Add the related_pages parameter to be able to display events by a filter on any page.