### PR TITLE
Contributors fix

### DIFF
--- a/_includes/contributor-carousel-selection.html
+++ b/_includes/contributor-carousel-selection.html
@@ -1,5 +1,5 @@
 {%- assign carousel_counter = carousel_counter | plus: 1 %}
-{%- assign contributors_lookup = site.data.CONTRIBUTORS %}
+{%- assign contributors_lookup = site.data.contributors | default: site.data.CONTRIBUTORS -%}
 {%- assign allcontrstr = nil %}
 {%- assign nr = include.col | default: 4 %}
 {%- if include.custom %}

--- a/_includes/contributor-minitiles-page.html
+++ b/_includes/contributor-minitiles-page.html
@@ -1,4 +1,4 @@
-{%- assign contributors_lookup = site.data.CONTRIBUTORS %}
+{%- assign contributors_lookup = site.data.contributors | default: site.data.CONTRIBUTORS -%}
 {%- unless include.sort == false %}
 {%- assign name_list = include.contributors_list | sort %}
 {%- else %}

--- a/_includes/contributor-tiles-all.html
+++ b/_includes/contributor-tiles-all.html
@@ -1,4 +1,4 @@
-{%- assign contributors_lookup = site.data.CONTRIBUTORS %}
+{%- assign contributors_lookup = site.data.contributors | default: site.data.CONTRIBUTORS -%}
 {%- assign allcontrstr = nil %}
 {%- assign nr = include.col | default: 4 %}
 {%- if include.custom %}

--- a/_includes/events.html
+++ b/_includes/events.html
@@ -2,8 +2,12 @@
   {%- if include.title == true%}
   <h2>{{include.event_type | replace: "_", " " | capitalize}}s</h2>
   {%- endif %}
+  {%- if include.related_pages %}
+  {%- assign filtered = site.data.events | where_exp: "event", "event.related_pages contains include.related_pages" %}
+  {%- assign events = filtered | sort: "startDate" | reverse %}
+  {%- else %}
   {%- assign events = site.data.events | sort: "startDate" | reverse %}
-  {%- assign count = 0 %}
+    {%- endif %}
   <ul class="list-unstyled mt-3">
     {%- for event in events %}
     <li class='{{include.event_type}}' data-start='{{ event.startDate}}'>


### PR DESCRIPTION
**Hardcoded case in contributor-tiles-all.html breaks lowercase contributors.yaml**

The template expects site.data.CONTRIBUTORS but data files are typically lowercase:
Expected: _data/contributors.yaml → site.data.contributors
Template: site.data.CONTRIBUTORS → nil
Fix: {%- assign contributors_lookup = site.data.contributors | default: site.data.CONTRIBUTORS -%}

Documentation does not warn of this requirement