### PR TITLE
News and events include redesign

### DIFF
--- a/_includes/events.html
+++ b/_includes/events.html
@@ -9,21 +9,24 @@
   {%- assign events = site.data.events | sort: "startDate" | reverse %}
     {%- endif %}
   {%- assign count = 0 %}
-  <ul class="list-unstyled mt-3">
+  <ul class="events-grid row row-cols-1 row-cols-md-{{ include.col | default: 1 }} g-4 list-unstyled mt-3">
     {%- for event in events %}
-    <li class='{{include.event_type}}' data-start='{{ event.startDate}}'>
-      <span class="title mb-1">{{ event.name | escape }}</span>
-      <p class="text-muted mb-0"><i class="far fa-calendar me-2"></i><time datetime="{{ event.startDate | date: '%e %B, %Y %H:%M' }}">{{ event.startDate | date_to_long_string }} {{event.startTime}}</time>
-        {% if event.endDate or event.endTime %} - <time datetime="{{ event.endDate | date: '%e %B, %Y %H:%M %Z' }}">{{ event.endDate | date_to_long_string }} {{event.endTime}}</time>{% endif %}</p>
-      {%- if event.location %}
-      <i class="fa-solid fa-map-marker-alt me-2 text-muted"></i>
-      <div class="d-inline-block text-muted">{{ event.location | markdownify }}</div>
-      {%- endif %}
+    <li class='col {{include.event_type}}' data-start='{{ event.startDate}}'>
+      <article class="event-card card h-100">
+      <div class="card-body d-flex flex-column p-4">
+      <div class="event-card-header d-flex align-items-start gap-3 mb-3">
+        <span class="event-card-icon d-inline-flex flex-shrink-0 align-items-center justify-content-center rounded-circle" aria-hidden="true"><i class="far fa-calendar"></i></span>
+        <div>
+          <h3 class="title mt-0 mb-0">{{ event.name | escape }}</h3>
+          <p class="event-card-date text-muted mt-1 mb-0"><time datetime="{{ event.startDate | date: '%e %B, %Y %H:%M' }}">{{ event.startDate | date_to_long_string }} {{event.startTime}}</time>
+            {% if event.endDate or event.endTime %}<span class="event-date-range-separator" aria-hidden="true">&ndash;</span><time datetime="{{ event.endDate | date: '%e %B, %Y %H:%M %Z' }}">{{ event.endDate | date_to_long_string }} {{event.endTime}}</time>{% endif %}{% if event.location %}<span class="metadata-separator" aria-hidden="true">&middot;</span><i class="fa-solid fa-map-marker-alt me-1" aria-hidden="true"></i><span>{{ event.location | markdownify | remove: '<p>' | remove: '</p>' | strip }}</span>{% endif %}</p>
+        </div>
+      </div>
       {%- if event.description %}
       {%- assign word_count = event.description | split: " " | size %}
       {%- if include.truncate == true and word_count > 40 %}
-      <p class="mb-0"><a data-bs-toggle="collapse" href="#collapse-{{count}}" role="button" aria-expanded="false" aria-controls="collapse-{{count}}">
-        View description
+      <p class="mb-0"><a class="description-toggle btn btn-outline-primary btn-sm d-inline-flex align-items-center gap-2" data-bs-toggle="collapse" href="#collapse-{{count}}" role="button" aria-expanded="false" aria-controls="collapse-{{count}}">
+        <i class="fa-solid fa-chevron-right" aria-hidden="true"></i><span>View description</span>
       </a>
       </p>
       <div class="full-description collapse" id="collapse-{{count}}">
@@ -33,6 +36,8 @@
       {{ event.description | markdownify }}
       {%- endif %}
       {%- endif %}
+      </div>
+      </article>
     </li>
     {%- assign count = count | plus: 1 %}
     {%- endfor %}

--- a/_includes/events.html
+++ b/_includes/events.html
@@ -9,7 +9,7 @@
   {%- assign events = site.data.events | sort: "startDate" | reverse %}
     {%- endif %}
   {%- assign count = 0 %}
-  <ul class="events-grid row row-cols-1 row-cols-md-{{ include.col | default: 1 }} g-4 list-unstyled mt-3">
+  <ul class="events-grid row row-cols-1 row-cols-md-{{ include.col | default: 1 }} gx-4 gy-0 list-unstyled mt-3">
     {%- for event in events %}
     <li class='col {{include.event_type}}' data-start='{{ event.startDate}}'>
       <article class="event-card card h-100">

--- a/_includes/events.html
+++ b/_includes/events.html
@@ -25,7 +25,7 @@
       {%- if event.description %}
       {%- assign word_count = event.description | split: " " | size %}
       {%- if include.truncate == true and word_count > 40 %}
-      <p class="mb-0"><a class="description-toggle btn btn-outline-primary btn-sm d-inline-flex align-items-center gap-2" data-bs-toggle="collapse" href="#collapse-{{count}}" role="button" aria-expanded="false" aria-controls="collapse-{{count}}">
+      <p class="mb-0"><a class="description-toggle btn btn-sm d-inline-flex align-items-center gap-2" data-bs-toggle="collapse" href="#collapse-{{count}}" role="button" aria-expanded="false" aria-controls="collapse-{{count}}">
         <i class="fa-solid fa-chevron-right" aria-hidden="true"></i><span>View description</span>
       </a>
       </p>

--- a/_includes/news.html
+++ b/_includes/news.html
@@ -4,16 +4,17 @@
   {%- endif %}
   {%- assign news = site.data.news | sort: "date" %}
   {%- assign count = 0 %}
-  <ul class="list-unstyled mt-3">
+  <ul class="news-timeline list-unstyled mt-3">
     {%- for new in news reversed%}
-    <li>
-      <span class="title mb-1">{{ new.name | escape }}</span>
-      <p class="text-muted"><i class="far fa-calendar me-2"></i><time>{{ new.date | date_to_long_string }}</time>{% if new.linked_pr %} - <i class="fa-solid fa-code-branch me-2"></i><a href="{{ site.github.repository_url | append: '/pull/' | append: new.linked_pr }}"><span>{{new.linked_pr }}</span></a>{% endif %}</p>
+    <li class="news-timeline-item">
+      <article class="news-timeline-content">
+      <h3 class="title mt-0 mb-2">{{ new.name | escape }}</h3>
+      <p class="news-timeline-date text-muted mb-3"><i class="far fa-calendar me-2" aria-hidden="true"></i><time>{{ new.date | date_to_long_string }}</time>{% if new.linked_pr %}<span class="metadata-separator" aria-hidden="true">&middot;</span><i class="fa-solid fa-code-branch me-2" aria-hidden="true"></i><a href="{{ site.github.repository_url | append: '/pull/' | append: new.linked_pr }}"><span>PR #{{new.linked_pr }}</span></a>{% endif %}</p>
       {%- if new.description %}
       {%- assign word_count = new.description | split: " " | size %}
       {%- if include.truncate == true and word_count > 40 %}
-      <p class="mb-0"><a data-bs-toggle="collapse" href="#collapse-{{count}}" role="button" aria-expanded="false" aria-controls="collapse-{{count}}">
-        View description
+      <p class="mb-0"><a class="description-toggle btn btn-outline-primary btn-sm d-inline-flex align-items-center gap-2" data-bs-toggle="collapse" href="#collapse-{{count}}" role="button" aria-expanded="false" aria-controls="collapse-{{count}}">
+        <i class="fa-solid fa-chevron-right" aria-hidden="true"></i><span>View description</span>
       </a>
       </p>
       <div class="full-description collapse" id="collapse-{{count}}">
@@ -23,6 +24,7 @@
       {{ new.description | markdownify }}
       {%- endif %}
       {%- endif %}
+      </article>
     </li>
     {%- assign count = count | plus: 1 %}
     {%- if include.limit and count == include.limit %}

--- a/_includes/news.html
+++ b/_includes/news.html
@@ -4,7 +4,7 @@
   {%- endif %}
   {%- assign news = site.data.news | sort: "date" %}
   {%- assign count = 0 %}
-  <ul class="news-timeline list-unstyled mt-3">
+  <ul class="news-timeline list-unstyled my-3">
     {%- for new in news reversed%}
     <li class="news-timeline-item">
       <article class="news-timeline-content">
@@ -13,7 +13,7 @@
       {%- if new.description %}
       {%- assign word_count = new.description | split: " " | size %}
       {%- if include.truncate == true and word_count > 40 %}
-      <p class="mb-0"><a class="description-toggle btn btn-outline-primary btn-sm d-inline-flex align-items-center gap-2" data-bs-toggle="collapse" href="#collapse-{{count}}" role="button" aria-expanded="false" aria-controls="collapse-{{count}}">
+      <p class="mb-0"><a class="description-toggle btn btn-sm d-inline-flex align-items-center gap-2" data-bs-toggle="collapse" href="#collapse-{{count}}" role="button" aria-expanded="false" aria-controls="collapse-{{count}}">
         <i class="fa-solid fa-chevron-right" aria-hidden="true"></i><span>View description</span>
       </a>
       </p>

--- a/_sass/_variables.scss
+++ b/_sass/_variables.scss
@@ -40,10 +40,9 @@ $page-metadata-bg: rgba($primary, 0.08);
 $page-metadata-link-bg: $white;
 $contr-popover-bg: $white;
 
-/*-----Events & news-----*/
-$news-title-bg: $primary;
-$news-border-color: $gray-300;
-$news-title-color: $white;
+/*-----News-----*/
+$news-accent-color: $primary;
+$news-timeline-color: $gray-300;
 
 /*-----Default badge-----*/
 $badge-color: $body-color;

--- a/_sass/_variables.scss
+++ b/_sass/_variables.scss
@@ -42,7 +42,7 @@ $contr-popover-bg: $white;
 
 /*-----Events & news-----*/
 $news-title-bg: $primary;
-$news-border-color: $light;
+$news-border-color: $gray-300;
 $news-title-color: $white;
 
 /*-----Default badge-----*/

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -1002,7 +1002,104 @@ footer {
     width: 35px;
 }
 
-/*-----News and events-----*/
+/*-----News-----*/
+
+.news-timeline {
+    --timeline-line-color: #{$news-border-color};
+    position: relative;
+    max-width: 72rem;
+    margin-bottom: 0;
+    padding-left: 2.5rem;
+
+    &::before {
+        position: absolute;
+        top: .75rem;
+        bottom: .75rem;
+        left: .45rem;
+        width: 2px;
+        background: var(--timeline-line-color);
+        content: "";
+    }
+}
+
+.news-timeline-item {
+    position: relative;
+    margin: 0;
+    padding: 0 0 2.5rem;
+
+    &:last-child {
+        padding-bottom: 0;
+    }
+
+}
+
+#main .news-timeline-item {
+    margin: 0;
+}
+
+.news-timeline-content {
+    .title {
+        position: relative;
+        color: $headings-color;
+        font-size: 1.2rem;
+        font-weight: 650;
+        line-height: 1.35;
+
+        &::before {
+            position: absolute;
+            z-index: 1;
+            top: 50%;
+            left: -2.4rem;
+            width: .9rem;
+            height: .9rem;
+            border: 3px solid $body-bg;
+            border-radius: 50%;
+            background: $news-title-bg;
+            box-shadow: 0 0 0 2px $news-border-color;
+            content: "";
+            transform: translateY(-50%);
+        }
+    }
+
+    > *:last-child,
+    .full-description > *:last-child {
+        margin-bottom: 0;
+    }
+}
+
+.news-timeline-date {
+    font-size: .9rem;
+    line-height: 1.45;
+
+    i {
+        width: 1.15rem;
+        text-align: center;
+    }
+}
+
+.metadata-separator {
+    margin: 0 .45rem;
+}
+
+.description-toggle .fa-chevron-right {
+    transition: transform .2s ease-in-out;
+}
+
+.description-toggle[aria-expanded="true"] .fa-chevron-right {
+    transform: rotate(90deg);
+}
+
+@media (max-width: 575.98px) {
+    .news-timeline {
+        padding-left: 2rem;
+    }
+
+    .news-timeline-content .title::before {
+        left: -2rem;
+    }
+}
+
+/*-----Events-----*/
 
 li.upcoming_event,
 li.past_event,
@@ -1010,33 +1107,47 @@ li.past_event,
     display: none;
 }
 
-.events>ul>li,
-.news>ul>li {
-    border-left: $news-border-color 5px solid;
-    border-radius: $border-radius;
-    padding: 0px 11px;
+.events-grid {
+    margin-bottom: 0;
+}
 
-    i {
-        width: 20px;
-        text-align: center;
-    }
+.events-grid > li,
+#main .events-grid > li {
+    min-width: 0;
+    margin: 0;
+    margin-top: var(--bs-gutter-y);
+}
+
+.event-card {
+    background-color: $nav-card-bg;
+    color: $nav-card-color;
 
     .title {
-        background-color: $news-title-bg;
-        font-weight: 600;
-        color: $news-title-color;
-        padding: 0px 11px;
-        border-radius: 0px 4px 4px 0px;
-        margin-left: -11px;
-        display: inline-block;
+        color: $headings-color;
+        font-size: 1.2rem;
+        font-weight: 650;
+        line-height: 1.35;
     }
 
-    .full-description>*:last-child {
+    .card-body > *:last-child,
+    .full-description > *:last-child {
         margin-bottom: 0;
+    }
+}
 
-        li {
-            margin-bottom: 0;
-        }
+.event-card-icon {
+    width: 2.5rem;
+    height: 2.5rem;
+    background: rgba($news-title-bg, .1);
+    color: $news-title-bg;
+}
+
+.event-card-date {
+    font-size: .9rem;
+    line-height: 1.45;
+
+    .event-date-range-separator {
+        margin: 0 .25rem;
     }
 }
 

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -1115,12 +1115,6 @@ li.past_event,
     margin-bottom: 0;
 }
 
-.events-grid > li,
-#main .events-grid > li {
-    min-width: 0;
-    margin: 0;
-    margin-top: var(--bs-gutter-y);
-}
 
 .event-card {
     background-color: $nav-card-bg;

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -1014,7 +1014,7 @@ footer {
     &::before {
         position: absolute;
         top: .75rem;
-        bottom: .75rem;
+        bottom: 0rem;
         left: .45rem;
         width: 2px;
         background: var(--timeline-line-color);
@@ -1079,6 +1079,10 @@ footer {
 
 .metadata-separator {
     margin: 0 .45rem;
+}
+
+.description-toggle {
+    margin-top: -1rem;
 }
 
 .description-toggle .fa-chevron-right {

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -1111,6 +1111,7 @@ li.past_event,
 }
 
 .events-grid {
+    row-gap: $spacer * 1.5;
     margin-bottom: 0;
 }
 

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -1048,7 +1048,7 @@ footer {
             position: absolute;
             z-index: 1;
             top: 50%;
-            left: -2.4rem;
+            left: -2.45rem;
             width: .9rem;
             height: .9rem;
             border: 3px solid $body-bg;

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -1005,7 +1005,6 @@ footer {
 /*-----News-----*/
 
 .news-timeline {
-    --timeline-line-color: #{$news-border-color};
     position: relative;
     max-width: 72rem;
     margin-bottom: 0;
@@ -1017,7 +1016,7 @@ footer {
         bottom: 0rem;
         left: .45rem;
         width: 2px;
-        background: var(--timeline-line-color);
+        background: $news-timeline-color;
         content: "";
     }
 }
@@ -1054,8 +1053,8 @@ footer {
             height: .9rem;
             border: 3px solid $body-bg;
             border-radius: 50%;
-            background: $news-title-bg;
-            box-shadow: 0 0 0 2px $news-border-color;
+            background: $news-accent-color;
+            box-shadow: 0 0 0 2px $news-timeline-color;
             content: "";
             transform: translateY(-50%);
         }
@@ -1136,8 +1135,8 @@ li.past_event,
 .event-card-icon {
     width: 2.5rem;
     height: 2.5rem;
-    background: rgba($news-title-bg, .1);
-    color: $news-title-bg;
+    background: rgba($news-accent-color, .1);
+    color: $news-accent-color;
 }
 
 .event-card-date {

--- a/pages/example_pages/events.md
+++ b/pages/example_pages/events.md
@@ -6,13 +6,13 @@ title: Events
 
 ```
 {% raw %}
-{% include events.html event_type="past_event" %}
+{% include events.html event_type="past_event" col=2 %}
 {% endraw %}
 ```
 
 Becomes:
 
-{% include events.html event_type="past_event" %}
+{% include events.html event_type="past_event" col=2 %}
 
 ## More complex example with upcoming events
 
@@ -34,6 +34,7 @@ Becomes:
 * `caption_url`: Add a custom url if the main events page is not served at */events*
 * `truncate`: If longer event descriptions are used and this parameter is set to *true*, descriptions which are longer than 40 words will get collapsed behind a button (`true` or `false`).
 * `limit`: Integer to determine the amount of news items shown.
+* `col`: Number of event columns shown from the medium breakpoint upwards. Defaults to `1`; use `col=2` for a two-column layout.
 * `related_pages`: A `page_id` assigned to the events that should be displayed. Add the same ID to each event's `related_pages` list in `_data/events.yml`.
 
 ## Filter events by related page


### PR DESCRIPTION
This will close #355 

🚨 **Breaking change** 🚨 : Theme variables, set in _sass/_variables.scss, were renamed to better reflect their use:
```
/*-----Events & news-----*/
$news-title-bg: $primary;
$news-border-color: $light;
$news-title-color: $white;
```
Become:
```
/*-----News-----*/
$news-accent-color: $primary;
$news-timeline-color: $gray-300;
```

Update any corresponding custom Sass overrides.

## Events

Before:
<img width="892" height="454" alt="image" src="https://github.com/user-attachments/assets/19c4553d-2cef-4049-b961-8d1e91847ba3" />

After:
<img width="892" height="454" alt="image" src="https://github.com/user-attachments/assets/f3ac6db2-34bd-4f05-a3e2-1e257cdda7b4" />

## News

Before:
<img width="892" height="613" alt="image" src="https://github.com/user-attachments/assets/9dddcb45-c141-49d4-932e-98df3b7d2621" />

After:
<img width="854" height="703" alt="image" src="https://github.com/user-attachments/assets/cf747612-bfd9-4dbd-a2d6-7b6683160a9a" />
