### PR TITLE
Adding ELIXIR-GOBLET Train-the-Trainer to known instances

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,12 +176,13 @@ This will start the docker container and serve the website locally. Make sure th
 - [Federated Learning toolkit (FLkit)](https://uhasselt-biomedicaldatasciences.github.io/federated-learning-toolkit/) (UHasselt)
 - [mTeSS-X](https://elixirtess.github.io/mTeSS-X/) (OSCARS project)
 - [Galaxy Codex](https://galaxyproject.github.io/galaxy_codex/) (Galaxy Community)
-- [ELIXIR Software Management Plan](https://elixir-europe.github.io/software-management-plans/community/) (ELIXIR SMP Community)
+- [ELIXIR Software Management Plan](https://elixir-europe.github.io/software-management-plans/) (ELIXIR SMP Community)
 - [FAIR Metroline](https://fairmetroline.org/) (Health-RI)
 - [Globus Community Australasia](https://aarnet.github.io/Globus-Community/) (AARNet)
 - [ELIXIR Research Software Ecosystem (RSEc)](https://research-software-ecosystem.github.io/) (ELIXIR Tools Platform)
 - [Knowledge Hub](https://knowledge.lnds.lu/) (Luxembourg National Data Service (LNDS))
 - [ELIXIR-ELITMa](https://elixir-europe-training.github.io/ELIXIR-ELITMa/) (ELIXIR Training platform)
+- [ELIXIR-GOBLET Train-the-Trainer](https://elixir-europe-training.github.io/ELIXIR-TrP-GOBLET-Train-the-Trainer/) (ELIXIR Training platform)
 - Want your instance here? [Open an issue](https://github.com/ELIXIR-Belgium/elixir-toolkit-theme/issues)
 
 ## Dependencies


### PR DESCRIPTION
* Updated the link for the `ELIXIR Software Management Plan` to point to the main project page instead of the community subpage.
* Added a new entry for `ELIXIR-GOBLET Train-the-Trainer` under the ELIXIR Training platform. closes #429 