### PR TITLE
Prioritize affiliations data over the supported-by fallback

### DIFF
--- a/_includes/section-navigation-tiles.html
+++ b/_includes/section-navigation-tiles.html
@@ -107,7 +107,7 @@
                 {%- endif %}
                 {%- if current_page_supported_by %}
                 {%- assign pageaffil = current_page_supported_by | sort %}
-                {%- assign alllogos = site.data.supported_by | default: site.data.affiliations %}
+                {%- assign alllogos = site.data.affiliations | default: site.data.supported_by %}
                 {%- assign allcountries = site.data.countries %}
                 <div class="d-flex align-items-center flex-wrap gap-2">
                     <span><b><small>Supported by:</small></b></span>

--- a/_includes/supported-by-tiles-page.html
+++ b/_includes/supported-by-tiles-page.html
@@ -1,4 +1,4 @@
-{%- assign supporter_data = site.data.supported_by | default: site.data.affiliations %}
+{%- assign supporter_data = site.data.affiliations | default: site.data.supported_by %}
 {%- assign supported_by_list = include.supported_by_list | default: include.affiliations_list %}
 {%- unless include.sort == false %}
 {%- assign supported_by_list = supported_by_list | sort %}

--- a/_includes/supported-by-tiles-selection.html
+++ b/_includes/supported-by-tiles-selection.html
@@ -1,4 +1,4 @@
-{%- assign alllogos = site.data.supported_by | default: site.data.affiliations %}
+{%- assign alllogos = site.data.affiliations | default: site.data.supported_by %}
 <div class="supported-by-tiles row row-cols-2 row-cols-sm-3 row-cols-md-4 g-4 my-3">
   {%- assign filtered_logos = alllogos %}
   {%- if include.type %}


### PR DESCRIPTION
Jekyll passes data files from remote themes into consuming sites. Because ETT now provides `supported_by`, it can incorrectly take precedence over a site’s existing `affiliations` data. Prioritizing `affiliations` preserves backwards compatibility for existing sites, while sites without it continue to use `supported_by`.