### PR TITLE
Improve top navigation styling

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -87,7 +87,6 @@ theme_variables:
     # min_headings: 1
     # headings: 'h2'
   # topnav:
-    # theme: light
     # brand_logo: assets/img/main_logo.svg
     # search: true
     # github: true

--- a/_data/topnav.yml
+++ b/_data/topnav.yml
@@ -1,8 +1,6 @@
 ## Topnav single links
 ## if you want to list an external url, use external_url instead of url. the theme will apply a different link base.
 subitems:
-- title: Main
-  url: /
 - title: About
   url: /about
 - title: Example dropdown

--- a/_includes/topnav.html
+++ b/_includes/topnav.html
@@ -3,7 +3,7 @@
     <a class="visually-hidden-focusable" href='#side-nav'>Skip to aside</a>
     <a class="visually-hidden-focusable" href='#main'>Skip to content</a>
     <a class="visually-hidden-focusable" href='#footer'>Skip to footer</a>
-    <nav class="navbar navbar-{{ site.theme_variables.topnav.theme | default: 'light' }} navbar-expand-lg mb-3 mb-lg-5 shadow-sm">
+    <nav class="navbar navbar-expand-lg mb-3 mb-lg-5 shadow-sm">
         <div class="container g-lg-5">
             <a class="navbar-brand flex-grow-1 overflow-x-auto" href="{{ '/' | relative_url }}"><img class="{% if site.topnav_title %}me-3 {% endif %}img-fluid" alt="{{site.title}} logo" src="{{ site.theme_variables.topnav.brand_logo | default: 'assets/img/main_logo.svg' | relative_url }}">{% if site.topnav_title %}<span class="me-0 me-lg-3">{{site.topnav_title}}</span>{% endif %}</a>
             <button class="navbar-toggler text-primary" type="button" data-bs-toggle="collapse" data-bs-target="#navbarCollapse" aria-controls="navbarCollapse" aria-expanded="false" aria-label="Toggle navigation">
@@ -44,13 +44,7 @@
                     </li>
                     {%- endfor %}
                     {%- if topnav.subitems.size > 1 %}
-                    {%- assign topnav_theme = site.theme_variables.topnav.theme | default: "light" %}
-                    {%- if topnav_theme == "light" %}
-                    {%- assign break_color = "dark" %}
-                    {%- else %}
-                    {%- assign break_color = "light" %}
-                    {%- endif -%}
-                    <li class="nav-item nav-break bg-{{break_color}} opacity-25"></li>
+                    <li class="nav-item nav-break" aria-hidden="true"></li>
                     {%- endif %}
                     {%- if site.theme_variables.topnav.twitter %}
                     <li class="nav-item">
@@ -87,7 +81,7 @@
                     {%- endif %}
                     {%- unless include.search == false %}
                     <!--start search-->
-                    <li class="nav-item">
+                    <li class="nav-item d-lg-flex align-items-center">
                         <div class="position-relative">
                             <form role="search" class="input-group">
                                 <span class="input-group-text" id="search-label"><i class="fa-solid fa-magnifying-glass"></i></span><input type="search" id="search-input" class="search-input form-control" tabindex="0" placeholder="Search..." aria-label="Search..." autocomplete="off">

--- a/_sass/_custom_classes.scss
+++ b/_sass/_custom_classes.scss
@@ -1,6 +1,0 @@
-/*-----Top navigation-----*/
-
-.navbar-nav .nav-item > a.active {
-    border-bottom: 4px solid $primary;
-    margin-bottom: -4px;
-}

--- a/_sass/_variables.scss
+++ b/_sass/_variables.scss
@@ -11,8 +11,10 @@ $topnav-bg: $light;
 $topnav-title-color: $primary;
 $topnav-brand-height: 44px;
 $topnav-searchbar: $white;
+$topnav-link-color: $navbar-light-color !default;
 $topnav-link-color-active: $primary !default;
 $topnav-link-bg-active: rgba($primary, 0.08) !default;
+$topnav-break-color: rgba($dark, 0.25) !default;
 
 /*-----Search-----*/
 $search-result-color: $primary;

--- a/_sass/_variables.scss
+++ b/_sass/_variables.scss
@@ -11,6 +11,8 @@ $topnav-bg: $light;
 $topnav-title-color: $primary;
 $topnav-brand-height: 44px;
 $topnav-searchbar: $white;
+$topnav-link-color-active: $primary !default;
+$topnav-link-bg-active: rgba($primary, 0.08) !default;
 
 /*-----Search-----*/
 $search-result-color: $primary;

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -422,14 +422,42 @@ div.highlight {
 
 header .navbar {
     background-color: $topnav-bg;
+
     #search-label, #search-input {
         background-color: $topnav-searchbar;
     }
+
     .navbar-brand {
         color: $topnav-title-color;
 
         img {
             max-height: $topnav-brand-height;
+        }
+    }
+
+    .navbar-nav > .nav-item > .nav-link:hover,
+    .navbar-nav > .nav-item > .nav-link.active {
+        color: $topnav-link-color-active;
+        background-color: $topnav-link-bg-active;
+        border-radius: $border-radius;
+    }
+
+    .dropdown-menu {
+        padding: $spacer * 0.5;
+        border: 0;
+        box-shadow: $box-shadow;
+    }
+
+    .dropdown-item {
+        border-radius: $border-radius;
+        transition: $transition-base;
+
+        &:hover,
+        &:focus,
+        &:active,
+        &.active {
+            color: $topnav-link-color-active;
+            background-color: $topnav-link-bg-active;
         }
     }
 }

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -437,13 +437,14 @@ header .navbar {
 
     .navbar-nav > .nav-item > .nav-link {
         color: $topnav-link-color;
+        border-radius: $border-radius;
+        transition: $transition-base;
     }
 
     .navbar-nav > .nav-item > .nav-link:hover,
     .navbar-nav > .nav-item > .nav-link.active {
         color: $topnav-link-color-active;
         background-color: $topnav-link-bg-active;
-        border-radius: $border-radius;
     }
 
     .dropdown-menu {

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -435,6 +435,10 @@ header .navbar {
         }
     }
 
+    .navbar-nav > .nav-item > .nav-link {
+        color: $topnav-link-color;
+    }
+
     .navbar-nav > .nav-item > .nav-link:hover,
     .navbar-nav > .nav-item > .nav-link.active {
         color: $topnav-link-color-active;
@@ -449,6 +453,7 @@ header .navbar {
     }
 
     .dropdown-item {
+        color: $topnav-link-color;
         border-radius: $border-radius;
         transition: $transition-base;
 
@@ -483,12 +488,30 @@ header .navbar {
 // Break line in top navigation
 
 .nav-break {
+    flex: 0 0 auto;
+    background: linear-gradient(
+        to right,
+        transparent,
+        $topnav-break-color 30%,
+        $topnav-break-color 70%,
+        transparent
+    );
+
     @include media-breakpoint-up(lg) {
         width: 1px;
+        align-self: stretch;
+        background: linear-gradient(
+            to bottom,
+            transparent,
+            $topnav-break-color 30%,
+            $topnav-break-color 70%,
+            transparent
+        );
     }
 
     @include media-breakpoint-down(lg) {
         height: 1px;
+        width: 100%;
     }
 }
 

--- a/pages/documentation/configuring_theme.md
+++ b/pages/documentation/configuring_theme.md
@@ -71,7 +71,6 @@ theme_variables:
     min_headings: 1
     headings: 'main h2'
   topnav:
-    theme: light
     brand_logo: assets/img/main_logo.svg
     search: true
     github: true
@@ -114,7 +113,6 @@ More detailed information about these settings can be found here:
   * `min_headings`: The minimum amount of headings (h2, h3,.. depending on the headings option) on a page for the toc to appear. This has to be an integer. Default: *1*
   * `headings`: The type of headings that need to be indexed by the toc. This can be a list or one value, ex: *'h1, h2, h3'* or *'h2'*. Default: *'main h2'*
 * **topnav**: Settings related to the top navigation.
-  *  `theme`: This variable is needed to change between a dark and a light top navigation. possible values: *dark* and *light*
   *  `brand_logo`: Custom path towards the brand logo, in case the assets/img/main_logo.svg can not be used.
   *  `search`:  Enable or disable the appearance of the search bar. Default: *true*
   *  `github`: Enable or disable the appearance of the Github repo nav link. Default: *true*
@@ -125,4 +123,3 @@ More detailed information about these settings can be found here:
 * `theme_color`: This is the primary theme color which is used in the metadata of the website. Please use the hex color without the hashtag as value.
 * `fonts`: List here the urls towards google fonts to include custom fonts for your website.
 * `breadcrumb`: Adds a breadcrumb above the title of every page. The breadcrumb will always represent the URL pattern and works best in combination with [permalink style](https://jekyllrb.com/docs/permalinks/#built-in-formats) *pretty*. Default: *false*
-

--- a/pages/documentation/custom_branding.md
+++ b/pages/documentation/custom_branding.md
@@ -18,6 +18,8 @@ theme_variables:
 
 Certain elements like the GitHub link have options in the `/_config.yml` file as described in the [configuring theme](configuring_theme) page. 
 
+Top navigation colors are controlled with Sass variables in `/_sass/_custom_variables.scss` as described below.
+
 ## Theme styling using CSS
 
 Bootstrap 5 is used as css library with the goal of reusing as much as possible to prevent a wild growth of classes and to make the html-code more understandable. SASS is used as css-precursor, a more structured and flexible language to describe the css styling. More information about the SASS language can be found [here](https://sass-lang.com/documentation/).
@@ -26,7 +28,7 @@ The order in which the css style sheets are loaded is as follows: bootstrap_vari
 
 ### 1. Bootstrap variables
 
-In the `/_sass/bootstrap_variables.scss` file, you can declare variables that can be used by Bootstrap. This is the very first place where one wants to customize their theme for things like:
+In the `/_sass/_bootstrap_variables.scss` file, you can declare variables that can be used by Bootstrap. This is the very first place where one wants to customize their theme for things like:
 
 - Primary, secondary, light and dark theme colors ($primary, $secondary, $light and $dark)
 - The size of H1, H2, p,... ($h1-font-size, $h2-font-size)
@@ -38,12 +40,13 @@ The variables that you can define, and their respective defaults, can be found i
 
 ### 2. Custom variables
 
-In the `/_sass/custom_variables.scss` file, you can declare variables that can be used by the theme. These are variables that are used by the theme to define the color, background-color, size and more of components like:
+In the `/_sass/_custom_variables.scss` file, you can declare variables that can be used by the theme. These are variables that are used by the theme to define the color, background-color, size and more of components like:
 
 - Sidebar background color and sidebar color ($sidebar-bg and $sidebar-color)
 - Background color of the top-navigation ($topnav-bg)
+- Active and hover styles of the top-navigation ($topnav-link-color-active and $topnav-link-bg-active)
 - Background color of the footer ($footer-bg)
-- Size of the branding logo in the top-navigation ($topnav-brand-heigh)
+- Size of the branding logo in the top-navigation ($topnav-brand-height)
 
 The variables that you can define, and their respective defaults, can be found in the [theme variables file](https://github.com/ELIXIR-Belgium/elixir-toolkit-theme/blob/main/_sass/_variables.scss). 
 


### PR DESCRIPTION
Adds themeable top navigation hover and active states matching the sidebar, modernizes dropdown styling with rounded items and search-result-like shadows, adds a fading topnav divider, and removes the custom active-page CSS.

## Theme config changes

Removing a theme variable:

```yml
theme_variables:
  topnav:
    theme: light
```

The `topnav.theme` variable is no longer used. Top navigation colors are now controlled through Sass variables instead.

## CSS/Sass variables

- New variables control top-navigation link, hover, active, and divider styles. Override them in `_sass/_custom_variables.scss` to match your branding:

```scss
/*-----Top navigation-----*/
$topnav-link-color: $navbar-light-color;
$topnav-link-color-active: $primary;
$topnav-link-bg-active: rgba($primary, 0.08);
$topnav-break-color: rgba($dark, 0.25);
```
Some screenshots:

<img width="1512" height="130" alt="image" src="https://github.com/user-attachments/assets/429b4179-997d-456b-b61c-8af5945972b2" />

<img width="1512" height="251" alt="image" src="https://github.com/user-attachments/assets/b925a5d5-395b-4340-ab6c-d58a7649267d" />
