### PR TITLE
Fix topnav artifacts in mobile

### DIFF
--- a/_includes/topnav.html
+++ b/_includes/topnav.html
@@ -6,7 +6,7 @@
     <nav class="navbar navbar-expand-lg mb-3 mb-lg-5 shadow-sm">
         <div class="container g-lg-5">
             <a class="navbar-brand flex-grow-1 overflow-x-auto" href="{{ '/' | relative_url }}"><img class="{% if site.topnav_title %}me-3 {% endif %}img-fluid" alt="{{site.title}} logo" src="{{ site.theme_variables.topnav.brand_logo | default: 'assets/img/main_logo.svg' | relative_url }}">{% if site.topnav_title %}<span class="me-0 me-lg-3">{{site.topnav_title}}</span>{% endif %}</a>
-            <button class="navbar-toggler text-primary" type="button" data-bs-toggle="collapse" data-bs-target="#navbarCollapse" aria-controls="navbarCollapse" aria-expanded="false" aria-label="Toggle navigation">
+            <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarCollapse" aria-controls="navbarCollapse" aria-expanded="false" aria-label="Toggle navigation">
                 <i title="navbar-toggler" class="fa-solid fa-bars"></i>
             </button>
             <div class="collapse navbar-collapse justify-content-end" id="navbarCollapse">

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -435,10 +435,24 @@ header .navbar {
         }
     }
 
+    .navbar-toggler {
+        color: $topnav-link-color-active;
+        -webkit-tap-highlight-color: transparent;
+
+        &:focus {
+            box-shadow: 0 0 0 0.15rem rgba($topnav-link-color-active, 0.25);
+        }
+
+        &:focus:not(:focus-visible) {
+            box-shadow: none;
+        }
+    }
+
     .navbar-nav > .nav-item > .nav-link {
         color: $topnav-link-color;
         border-radius: $border-radius;
         background-clip: padding-box;
+        -webkit-tap-highlight-color: transparent;
         transition: color 0.15s ease-in-out, background-color 0.15s ease-in-out;
     }
 
@@ -463,6 +477,7 @@ header .navbar {
     .dropdown-item {
         color: $topnav-link-color;
         border-radius: $border-radius;
+        -webkit-tap-highlight-color: transparent;
         transition: color 0.15s ease-in-out, background-color 0.15s ease-in-out;
 
         &:hover,
@@ -878,6 +893,7 @@ footer {
     a {
         color: $footer-link-color !important;
         font-weight: bold;
+        -webkit-tap-highlight-color: transparent;
     }
 
     a:hover {

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -438,11 +438,14 @@ header .navbar {
     .navbar-nav > .nav-item > .nav-link {
         color: $topnav-link-color;
         border-radius: $border-radius;
-        transition: $transition-base;
+        background-clip: padding-box;
+        transition: color 0.15s ease-in-out, background-color 0.15s ease-in-out;
     }
 
     .navbar-nav > .nav-item > .nav-link:hover,
-    .navbar-nav > .nav-item > .nav-link.active {
+    .navbar-nav > .nav-item > .nav-link:focus,
+    .navbar-nav > .nav-item > .nav-link.active,
+    .navbar-nav > .nav-item > .nav-link.show {
         color: $topnav-link-color-active;
         background-color: $topnav-link-bg-active;
     }
@@ -450,13 +453,17 @@ header .navbar {
     .dropdown-menu {
         padding: $spacer * 0.5;
         border: 0;
-        box-shadow: $box-shadow;
+        box-shadow: none;
+
+        @include media-breakpoint-up(lg) {
+            box-shadow: $box-shadow;
+        }
     }
 
     .dropdown-item {
         color: $topnav-link-color;
         border-radius: $border-radius;
-        transition: $transition-base;
+        transition: color 0.15s ease-in-out, background-color 0.15s ease-in-out;
 
         &:hover,
         &:focus,


### PR DESCRIPTION
On mobile, Bootstrap renders the dropdown menu inline, so the new dropdown box-shadow was bleeding upward into the active dropdown toggle and looking like that weird extra piece. 