### PR TITLE
Use sort_natural for sorting section navigation tiles

### DIFF
--- a/_includes/section-navigation-tiles.html
+++ b/_includes/section-navigation-tiles.html
@@ -54,7 +54,7 @@
     {%- if include.custom %}
     {%- assign related_pages = include.custom | split: ", " %}
     {%- unless include.sort == false %}
-    {%- assign related_pages = related_pages | sort %}
+    {%- assign related_pages = related_pages | sort_natural %}
     {%- endunless %}
     {%- elsif include.type %}
     {%- assign related_pages = site.pages | where:"type", include.type %}
@@ -62,7 +62,7 @@
     {%- assign related_pages = site.pages %}
     {%- endif %}
     {%- unless include.sort == false %}
-    {%- assign related_pages = related_pages | sort: 'title'%}
+    {%- assign related_pages = related_pages | sort_natural: 'title'%}
     {%- endunless %}
     {%- for related_page in related_pages %}
     {%- if include.custom %}


### PR DESCRIPTION
Ensures that titles/page ids are sorted in a case insensitive way.